### PR TITLE
Fix bonferroni corr. to prevent p>1

### DIFF
--- a/goatools/multiple_testing.py
+++ b/goatools/multiple_testing.py
@@ -36,6 +36,9 @@ class Bonferroni(AbstractCorrection):
     def set_correction(self):
         self.corrected_pvals *= self.n
 
+        # reset all pvals > 1 to 1
+        self.corrected_pvals[self.corrected_pvals > 1] = 1
+
 
 class Sidak(AbstractCorrection):
     """http://en.wikipedia.org/wiki/Bonferroni_correction


### PR DESCRIPTION
Imho the corrected bonferroni p-values should not be larger than 1. This may need to be changed as well for the other methods. Thanks. M.
