### PR TITLE
hack to fix seek() inconsistency

### DIFF
--- a/goatools/obo_parser.py
+++ b/goatools/obo_parser.py
@@ -46,8 +46,8 @@ class OBOReader:
     def __init__(self, obo_file="go-basic.obo"):
 
         try:
-            self._handle = open(obo_file)
-        except:
+            self._handle = open(obo_file,buffering=0) #dirty hack to fix seek() inconsistency
+       except:
             print(("download obo file first\n "
                                  "[http://purl.obolibrary.org/obo/"
                                  "go/go-basic.obo]"), file=sys.stderr)


### PR DESCRIPTION
tell() and seek() are only consistent when not using a buffer
a better solution would probably be to rewrite the parser so it doesn't need seek().
I am not sure why no one reported the bug but it leads to an infinite loop.
https://github.com/tanghaibao/goatools/issues/39