### PR TITLE
The changes allow find_enrichment and map_to_slip to read association files in other format 

### DIFF
--- a/scripts/find_enrichment.py
+++ b/scripts/find_enrichment.py
@@ -42,17 +42,42 @@ def read_geneset(study_fn, pop_fn, compare=False):
 
 
 def read_associations(assoc_fn):
+    """
+    Reads a gene id go term association file. The format of the file
+    is as follows:
+
+    AAR1	GO:0005575;GO:0003674;GO:0006970;GO:0006970;GO:0040029
+    AAR2	GO:0005575;GO:0003674;GO:0040029;GO:0009845
+    ACD5	GO:0005575;GO:0003674;GO:0008219
+    ACL1	GO:0005575;GO:0003674;GO:0009965;GO:0010073
+    ACL2	GO:0005575;GO:0003674;GO:0009826
+    ACL3	GO:0005575;GO:0003674;GO:0009826;GO:0009965
+
+    Also, the following format is accepted (gene ids are repeated):
+
+    AAR1	GO:0005575
+    AAR1    GO:0003674
+    AAR1    GO:0006970
+    AAR2	GO:0005575
+    AAR2    GO:0003674
+    AAR2    GO:0040029
+
+    :param assoc_fn: file name of the association
+    :return: dictionary having keys: gene id, values set of GO terms
+    """
     assoc = {}
-    for row in open(assoc_fn):
+    for row in open(assoc_fn, 'r'):
         atoms = row.split()
         if len(atoms) == 2:
-            a, b = atoms
+            gene_id, go_terms = atoms
         elif len(atoms) > 2 and row.count('\t') == 1:
-            a, b = row.split("\t")
+            gene_id, go_terms = row.split("\t")
         else:
             continue
-        b = set(b.split(";"))
-        assoc[a] = b
+        go_terms = set(go_terms.split(";"))
+        if gene_id in assoc:
+            assoc[gene_id] = assoc[gene_id].union(go_terms)
+        assoc[gene_id] = go_terms
 
     return assoc
 

--- a/scripts/map_to_slim.py
+++ b/scripts/map_to_slim.py
@@ -13,17 +13,42 @@ from goatools.mapslim import mapslim
 # copied from find_enrichment.py
 # TODO: put this method into the library, copying is BAD practise
 def read_associations(assoc_fn):
+    """
+    Reads a gene id go term association file. The format of the file
+    is as follows:
+
+    AAR1	GO:0005575;GO:0003674;GO:0006970;GO:0006970;GO:0040029
+    AAR2	GO:0005575;GO:0003674;GO:0040029;GO:0009845
+    ACD5	GO:0005575;GO:0003674;GO:0008219
+    ACL1	GO:0005575;GO:0003674;GO:0009965;GO:0010073
+    ACL2	GO:0005575;GO:0003674;GO:0009826
+    ACL3	GO:0005575;GO:0003674;GO:0009826;GO:0009965
+
+    Also, the following format is accepted (gene ids are repeated):
+
+    AAR1	GO:0005575
+    AAR1    GO:0003674
+    AAR1    GO:0006970
+    AAR2	GO:0005575
+    AAR2    GO:0003674
+    AAR2    GO:0040029
+
+    :param assoc_fn: file name of the association
+    :return: dictionary having keys: gene id, values set of GO terms
+    """
     assoc = {}
-    for row in open(assoc_fn):
+    for row in open(assoc_fn, 'r'):
         atoms = row.split()
         if len(atoms) == 2:
-            a, b = atoms
+            gene_id, go_terms = atoms
         elif len(atoms) > 2 and row.count('\t') == 1:
-            a, b = row.split("\t")
+            gene_id, go_terms = row.split("\t")
         else:
             continue
-        b = set(b.split(";"))
-        assoc[a] = b
+        go_terms = set(go_terms.split(";"))
+        if gene_id in assoc:
+            assoc[gene_id] = assoc[gene_id].union(go_terms)
+        assoc[gene_id] = go_terms
 
     return assoc
 


### PR DESCRIPTION
The changes allow find_enrichment and map_to_slip to read association files in which the gene name is repeated multiple times, each time with a different GO association. This is a common format, for example for Biomart.

I also improve the readability of the code.