### PR TITLE
Relationships in the GO

### DIFF
--- a/goatools/obo_parser.py
+++ b/goatools/obo_parser.py
@@ -32,6 +32,8 @@ class OBOReader(object):
         self._init_optional_attrs(optional_attrs)
         self.format_version = None
         self.data_version = None
+        self.typedefs = {}
+
         # True if obo file exists or if a link to an obo file exists.
         if os.path.isfile(obo_file):
             self.obo_file = obo_file
@@ -47,22 +49,30 @@ class OBOReader(object):
         # Wait to open file until needed. Automatically close file when done.
         with open(self.obo_file) as fstream:
             rec_curr = None # Stores current GO Term
+            typedef_curr = None  # Stores current typedef
             for lnum, line in enumerate(fstream):
                 # obo lines start with any of: [Term], [Typedef], /^\S+:/, or /^\s*/
                 if self.data_version is None:
                     self._init_obo_version(line)
-                if line[0:6] == "[Term]":
+                if line[0:6].lower() == "[term]":
                     rec_curr = self._init_goterm_ref(rec_curr, "Term", lnum)
-                elif line[0:9] == "[Typedef]":
-                    pass # Original OBOReader did not store these
-                elif rec_curr is not None:
+                elif line[0:9].lower() == "[typedef]":
+                    typedef_curr = self._init_typedef(rec_curr, "Typedef", lnum)
+                elif rec_curr is not None or typedef_curr is not None:
                     line = line.rstrip() # chomp
                     if ":" in line:
-                        self._add_to_ref(rec_curr, line, lnum)
+                        if rec_curr is not None:
+                            self._add_to_ref(rec_curr, line, lnum)
+                        else:
+                            self._add_to_typedef(typedef_curr, line, lnum)
                     elif line == "":
                         if rec_curr is not None:
                             yield rec_curr
                             rec_curr = None
+                        elif typedef_curr is not None:
+                            # Save typedef.
+                            self.typedefs[typedef_curr.id] = typedef_curr
+                            typedef_curr = None
                     else:
                         self._die("UNEXPECTED LINE CONTENT: {L}".format(L=line), lnum)
             # Return last record, if necessary
@@ -83,6 +93,13 @@ class OBOReader(object):
         msg = "PREVIOUS {REC} WAS NOT TERMINATED AS EXPECTED".format(REC=name)
         self._die(msg, lnum)
 
+    def _init_typedef(self, typedef_curr, name, lnum):
+        """Initialize new typedef and perform checks."""
+        if typedef_curr is None:
+            return TypeDef()
+        msg = "PREVIOUS {REC} WAS NOT TERMINATED AS EXPECTED".format(REC=name)
+        self._die(msg, lnum)
+
     def _add_to_ref(self, rec_curr, line, lnum):
         """Add new fields to the current reference."""
         # Written by DV Klopfenstein
@@ -99,7 +116,7 @@ class OBOReader(object):
             if field_name == "id":
                 self._chk_none(rec_curr.id, lnum)
                 rec_curr.id = field_value
-            if field_name == "alt_id":
+            elif field_name == "alt_id":
                 rec_curr.alt_ids.append(field_value)
             elif field_name == "name":
                 self._chk_none(rec_curr.name, lnum)
@@ -143,6 +160,28 @@ class OBOReader(object):
                 name = '_{:s}'.format(name)
                 setattr(rec, name, defaultdict(list))
                 self._add_nested(rec, name, value)
+
+    def _add_to_typedef(self, typedef_curr, line, lnum):
+        """Add new fields to the current typedef."""
+        mtch = re.match(r'^(\S+):\s*(\S.*)$', line)
+        if mtch:
+            field_name = mtch.group(1)
+            field_value = mtch.group(2).split('!')[0].rstrip()
+
+            if field_name == "id":
+                self._chk_none(typedef_curr.id, lnum)
+                typedef_curr.id = field_value
+            elif field_name == "name":
+                self._chk_none(typedef_curr.name, lnum)
+                typedef_curr.name = field_value
+            elif field_name == "transitive_over":
+                typedef_curr.transitive_over.append(field_value)
+            elif field_name == "inverse_of":
+                self._chk_none(typedef_curr.inverse_of, lnum)
+                typedef_curr.inverse_of = field_value
+            # Note: there are other tags that aren't imported here.
+        else:
+            self._die("UNEXPECTED FIELD CONTENT: {L}\n".format(L=line), lnum)
 
     def _add_nested(self, rec, name, value):
         """Adds a term's nested attributes."""
@@ -318,6 +357,30 @@ class GOTerm:
                 depth, dp)
 
 
+class TypeDef(object):
+    """
+        TypeDef term. These contain more tags than included here, but these
+        are the most important.
+    """
+
+    def __init__(self):
+        self.id = ""                # GO:NNNNNNN
+        self.name = ""              # description
+        self.transitive_over = []   # List of other typedefs
+        self.inverse_of = ""        # Name of inverse typedef.
+
+    def __str__(self):
+        ret = []
+        ret.append("Typedef - {} ({}):".format(self.id, self.name))
+        ret.append("  Inverse of: {}".format(self.inverse_of
+                                             if self.inverse_of else "None"))
+        if self.transitive_over:
+            ret.append("  Transitive over:")
+            for t in self.transitive_over:
+                ret.append("    - {}".format(t))
+        return "\n".join(ret)
+
+
 class GODag(dict):
 
     def __init__(self, obo_file="go-basic.obo", optional_attrs=None):
@@ -334,6 +397,10 @@ class GODag(dict):
 
         print("{OBO}: format-version({FMT}) data-version({REL})".format(
             OBO=obo_file, FMT=reader.format_version, REL=reader.data_version))
+
+        # Save the typedefs and parsed optional_attrs
+        self.typedefs = reader.typedefs
+        self.optional_attrs = reader.optional_attrs
 
         self.populate_terms()
         print(len(self), "nodes imported", file=sys.stderr)
@@ -361,16 +428,27 @@ class GODag(dict):
             rec.parents = [self[x] for x in rec._parents]
 
             if hasattr(rec, '_relationship'):
-                rec.relationship = defaultdict(list)
+                rec.relationship = defaultdict(set)
                 for (typedef, terms) in rec._relationship.items():
-                    rec.relationship[typedef] = [self[x] for x in terms]
+                    rec.relationship[typedef].update(set([self[x] for x in terms]))
                 delattr(rec, '_relationship')
 
-        # populate children and levels
+        # populate children, levels and add inverted relationships
         for rec in self.values():
             for p in rec.parents:
                 if rec not in p.children:
                     p.children.append(rec)
+
+            # Add invert relationships
+            if hasattr(rec, 'relationship'):
+                for (typedef, terms) in rec.relationship.items():
+                    invert_typedef = self.typedefs[typedef].inverse_of
+                    if invert_typedef:
+                        # Add inverted relationship
+                        for t in terms:
+                            if not hasattr(t, 'relationship'):
+                                t.relationship = defaultdict(set)
+                            t.relationship[invert_typedef].add(rec)
 
             if rec.level is None:
                 _init_level(rec)

--- a/goatools/semantic.py
+++ b/goatools/semantic.py
@@ -3,7 +3,8 @@
 
 """
 Compute semantic similarities between GO terms. Borrowed from book chapter from
-Christophe Dessimoz (thanks). For details, please check out:
+Alex Warwick Vesztrocy and Christophe Dessimoz (thanks). For details, please
+check out:
 notebooks/semantic_similarity.ipynb
 """
 

--- a/notebooks/relatonships_in_the_go.ipynb
+++ b/notebooks/relatonships_in_the_go.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Relationships in the GO\n",
+    "_Alex Warwick Vesztrocy, March 2016_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For some analyses, it is possible to only use the <code>is_a</code> definitions given in the Gene Ontology. \n",
+    "\n",
+    "However, it is important to remember that this isn't always the case. As such, <code>GOATOOLS</code> includes the option to load the relationship definitions also."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading GO graph with the relationship tags\n",
+    "This is possible by using the <code>optional_attrs</code> argument, upon instantiating a <code>GODag</code>. This can be done with either the full or the basic version of the ontology. Here, the __full__ version shall be used. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "load obo file go.obo\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "go.obo: format-version(1.2) data-version(releases/2016-03-26)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "46317 nodes imported\n"
+     ]
+    }
+   ],
+   "source": [
+    "from goatools.obo_parser import GODag\n",
+    "import wget\n",
+    "\n",
+    "go_fn = wget.download('http://geneontology.org/ontology/go.obo')\n",
+    "go = GODag(go_fn, optional_attrs=['relationship'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Viewing relationships in the GO graph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So now, when looking at an individual term (which has relationships defined in the GO) these are listed in a nested manner. As an example, look at <code>GO:1901990</code> which has a single <code>has_part</code> relationship, as well as a <code>regulates</code> one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "eg_term = go['GO:1901990']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GOTerm('GO:1901990'):\n",
+       "  name:regulation of mitotic cell cycle phase transition\n",
+       "  children: 7 items\n",
+       "    GO:0060564\tlevel-07\tdepth-13\tnegative regulation of APC-Cdc20 complex activity [biological_process] \n",
+       "    GO:2000045\tlevel-07\tdepth-08\tregulation of G1/S transition of mitotic cell cycle [biological_process] \n",
+       "    GO:1901992\tlevel-07\tdepth-08\tpositive regulation of mitotic cell cycle phase transition [biological_process] \n",
+       "    GO:1901991\tlevel-07\tdepth-08\tnegative regulation of mitotic cell cycle phase transition [biological_process] \n",
+       "    GO:0010389\tlevel-07\tdepth-08\tregulation of G2/M transition of mitotic cell cycle [biological_process] \n",
+       "    GO:0030071\tlevel-07\tdepth-10\tregulation of mitotic metaphase/anaphase transition [biological_process] \n",
+       "    GO:0007096\tlevel-07\tdepth-08\tregulation of exit from mitosis [biological_process] \n",
+       "  parents: 2 items\n",
+       "    GO:0007346\tlevel-05\tdepth-05\tregulation of mitotic cell cycle [biological_process] \n",
+       "    GO:1901987\tlevel-06\tdepth-06\tregulation of cell cycle phase transition [biological_process] \n",
+       "  level:6\n",
+       "  depth:7\n",
+       "  alt_ids: 0 items\n",
+       "  _parents: 2 items\n",
+       "    GO:0007346\n",
+       "    GO:1901987\n",
+       "  relationship: 2 items\n",
+       "    has_part: 1 items\n",
+       "      GO:0051437\tlevel-07\tdepth-12\tpositive regulation of ubiquitin-protein ligase activity involved in regulation of mitotic cell cycle transition [biological_process] \n",
+       "    regulates: 1 items\n",
+       "      GO:0044772\tlevel-05\tdepth-05\tmitotic cell cycle phase transition [biological_process] \n",
+       "  id:GO:1901990\n",
+       "  namespace:biological_process\n",
+       "  is_obsolete:False"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eg_term"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These different relationship types are stored as a dictionary within the relationship attribute on a GO term."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['has_part', 'regulates'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(eg_term.relationship.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{GOTerm('GO:0044772'):\n",
+      "  name:mitotic cell cycle phase transition\n",
+      "  children: 4 items\n",
+      "    GO:0000086\tlevel-06\tdepth-06\tG2/M transition of mitotic cell cycle [biological_process] \n",
+      "    GO:0007091\tlevel-06\tdepth-10\tmetaphase/anaphase transition of mitotic cell cycle [biological_process] \n",
+      "    GO:0010458\tlevel-06\tdepth-06\texit from mitosis [biological_process] \n",
+      "    GO:0000082\tlevel-06\tdepth-06\tG1/S transition of mitotic cell cycle [biological_process] \n",
+      "  parents: 2 items\n",
+      "    GO:0044770\tlevel-04\tdepth-04\tcell cycle phase transition [biological_process] \n",
+      "    GO:1903047\tlevel-04\tdepth-04\tmitotic cell cycle process [biological_process] \n",
+      "  level:5\n",
+      "  depth:5\n",
+      "  alt_ids: 0 items\n",
+      "  _parents: 2 items\n",
+      "    GO:0044770\n",
+      "    GO:1903047\n",
+      "  relationship: 1 items\n",
+      "    part_of: 1 items\n",
+      "      GO:0000278\tlevel-04\tdepth-04\tmitotic cell cycle [biological_process] \n",
+      "  id:GO:0044772\n",
+      "  namespace:biological_process\n",
+      "  is_obsolete:False}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(eg_term.relationship['regulates'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example use case\n",
+    "One example use case for the relationship terms, would be to look for all functions which regulate pseudohyphal growth (<code>GO:0007124</code>). That is:\n",
+    "\n",
+    "> A pattern of cell growth that occurs in conditions of nitrogen limitation and abundant fermentable carbon source. Cells become elongated, switch to a unipolar budding pattern, remain physically attached to each other, and invade the growth substrate. \n",
+    ">\n",
+    "> _Source: https://www.ebi.ac.uk/QuickGO/GTerm?id=GO:0007124#term=info&info=1_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "term_of_interest = go['GO:0007124']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, find the relationship types which contain \"regulates\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "frozenset({'positively_regulates', 'negatively_regulates', 'regulates'})\n"
+     ]
+    }
+   ],
+   "source": [
+    "regulates = frozenset([typedef \n",
+    "                       for typedef in go.typedefs.keys() \n",
+    "                       if 'regulates' in typedef])\n",
+    "print(regulates)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, search through the terms in the tree for those with a relationship in this list and add them to a dictionary dependent on the type of regulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "\n",
+    "regulating_terms = defaultdict(list)\n",
+    "\n",
+    "for t in go.values():\n",
+    "    if hasattr(t, 'relationship'):\n",
+    "        for typedef in regulates.intersection(t.relationship.keys()):\n",
+    "            if term_of_interest in t.relationship[typedef]:\n",
+    "                regulating_terms['{:s}d_by'.format(typedef[:-1])].append(t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now <code>regulating_terms</code> contains the GO terms which relate to regulating protein localisation to the nucleolus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pseudohyphal growth (GO:0007124) is:\n",
+      "\n",
+      "  - negatively_regulated_by:\n",
+      "    -- GO:1900462 negative regulation of pseudohyphal growth by negative regulation of transcription from RNA polymerase II promoter\n",
+      "    -- GO:2000221 negative regulation of pseudohyphal growth\n",
+      "    -- GO:0100042 negative regulation of pseudohyphal growth by transcription from RNA polymerase II promoter\n",
+      "\n",
+      "  - positively_regulated_by:\n",
+      "    -- GO:2000222 positive regulation of pseudohyphal growth\n",
+      "    -- GO:0100041 positive regulation of pseudohyphal growth by transcription from RNA polymerase II promoter\n",
+      "    -- GO:1900461 positive regulation of pseudohyphal growth by positive regulation of transcription from RNA polymerase II promoter\n",
+      "\n",
+      "  - regulated_by:\n",
+      "    -- GO:2000220 regulation of pseudohyphal growth\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('{:s} ({:s}) is:'.format(term_of_interest.name, term_of_interest.id))\n",
+    "for (k, v) in regulating_terms.items():\n",
+    "    print('\\n  - {:s}:'.format(k))\n",
+    "    for t in v:\n",
+    "        print('    -- {:s} {:s}'.format(t.id, t.name))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/semantic_similarity.ipynb
+++ b/notebooks/semantic_similarity.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Adapted from book chapter written by _Christophe Dessimoz_"
+    "Adapted from book chapter written by _Alex Warwick Vesztrocy and Christophe Dessimoz_"
    ]
   },
   {


### PR DESCRIPTION
Relationships can be included using the optional_attrs option of GODag, e.g.
`GODag(go_fn, optional_attrs=['relationship'])
`

Relationships are now parsed when imported and included in a nested structure. Pretty printing has been updated also. Inferred inverse relationships are included, but generalised by using the typedefs in the OBO file (e.g., for part_of/has_part).

There is an iPython notebook to look at all of this (PDF version attached - [relatonships_in_the_go.pdf](https://github.com/tanghaibao/goatools/files/196313/relatonships_in_the_go.pdf)).


I have also corrected the authorship in the semantic distance code to both Christophe Dessimoz and myself.