### PR TITLE
Open ungzipped file in binary mode

### DIFF
--- a/goatools/base.py
+++ b/goatools/base.py
@@ -141,7 +141,7 @@ def gunzip(gz, file_gunzip=None):
     if file_gunzip is None:
         file_gunzip = os.path.splitext(gz)[0]
     with gzip.open(gz, 'rb') as zstrm:
-        with  open(file_gunzip, 'w') as ostrm:
+        with  open(file_gunzip, 'wb') as ostrm:
             ostrm.write(zstrm.read())
     os.remove(gz)
     return file_gunzip


### PR DESCRIPTION
This fixes an error under Python 3, for which the write
function expects a `str` object while it receives a `bytes` object.

Fixes issue #67 