### PR TITLE
Relative path for setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@
 
 from setuptools import setup
 from glob import glob
+import os
 
-
+setup_dir = path.abspath(path.dirname(__file__))
 classifiers = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Science/Research',
@@ -16,9 +17,9 @@ classifiers = [
     ]
 
 requirements = ['wget'] + [x.strip() for x in
-                           open('requirements.txt').readlines()]
+                           open(os.path.join(setup_dir, 'requirements.txt')).readlines()]
 
-exec(open("goatools/version.py").read())
+exec(open(os.path.join(setup_dir, "goatools", "version.py")).read())
 setup(
     name="goatools",
     version=__version__,
@@ -30,6 +31,6 @@ setup(
     classifiers=classifiers,
     url='http://github.com/tanghaibao/goatools',
     description="Python scripts to find enrichment of GO terms",
-    long_description=open("README.md").read(),
+    long_description=open(os.path.join(setup_dir, "README.md")).read(),
     install_requires=requirements
     )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from glob import glob
 import os
 
-setup_dir = path.abspath(path.dirname(__file__))
+setup_dir = path.abspath(os.path.dirname(__file__))
 classifiers = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from glob import glob
 import os
 
-setup_dir = path.abspath(os.path.dirname(__file__))
+setup_dir = os.path.abspath(os.path.dirname(__file__))
 classifiers = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Science/Research',


### PR DESCRIPTION
Adding relative path to open( files) in setup. When installing I get an error due to relative path.

  Downloading goatools-0.7.6.tar.gz (53kB)
    100% |████████████████████████████████| 61kB 2.3MB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-vg_81kde/goatools/setup.py", line 33, in <module>
        long_description=open("README.md").read(),
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'