### PR TITLE
Don't display ERROR in get_id2gos (thanks @yuanning-li, #152)

### DIFF
--- a/goatools/anno/annoreader_base.py
+++ b/goatools/anno/annoreader_base.py
@@ -112,7 +112,7 @@ class AnnoReaderBase(object):
                 prt.write('{N} IDs in loaded association branch, {NS}\n'.format(N=len(id2gos), NS=nspc))
             return id2gos
         if self.godag is None:
-            logging.warning('%s(..., godag=None).get_id2gos: GODAG is None. IGNORING namespace(%s)\n',
+            logging.warning('%s.get_id2gos: GODAG is None. IGNORING namespace(%s). If you are running `map_to_slim.py`, this warning can be ignored.\n',
                             type(self).__name__, namespace)
         id2gos = self._get_id2gos(self.associations, **kws)
         if prt:

--- a/goatools/anno/annoreader_base.py
+++ b/goatools/anno/annoreader_base.py
@@ -111,8 +111,8 @@ class AnnoReaderBase(object):
             if prt:
                 prt.write('{N} IDs in loaded association branch, {NS}\n'.format(N=len(id2gos), NS=nspc))
             return id2gos
-        if self.godag is None:
-            logging.warning('%s.get_id2gos: GODAG is None. IGNORING namespace(%s). If you are running `map_to_slim.py`, this warning can be ignored.\n',
+        if prt and self.godag is None:
+            logging.warning('%s.get_id2gos: GODAG is None. IGNORING namespace(%s). If you are running `map_to_slim.py`, this warning can be ignored.',
                             type(self).__name__, namespace)
         id2gos = self._get_id2gos(self.associations, **kws)
         if prt:

--- a/goatools/anno/annoreader_base.py
+++ b/goatools/anno/annoreader_base.py
@@ -4,6 +4,8 @@ import sys
 import timeit
 import datetime
 import collections as cx
+import logging
+
 from goatools.evidence_codes import EvidenceCodes
 from goatools.anno.opts import AnnoOptions
 from goatools.godag.consts import NAMESPACE2NS
@@ -109,9 +111,9 @@ class AnnoReaderBase(object):
             if prt:
                 prt.write('{N} IDs in loaded association branch, {NS}\n'.format(N=len(id2gos), NS=nspc))
             return id2gos
-        if prt and namespace is not None:
-            print('**ERROR {CLS}(..., godag=None).get_id2gos: GODAG is None. IGNORING namespace({NS})\n'.format(
-                NS=namespace, CLS=type(self).__name__))
+        if prt and self.godag is None:
+            logging.warning('%s(..., godag=None).get_id2gos: GODAG is None. IGNORING namespace(%s)\n',
+                            type(self).__name__, namespace)
         id2gos = self._get_id2gos(self.associations, **kws)
         if prt:
             prt.write('{N} IDs in all associations\n'.format(N=len(id2gos)))

--- a/goatools/anno/annoreader_base.py
+++ b/goatools/anno/annoreader_base.py
@@ -111,7 +111,7 @@ class AnnoReaderBase(object):
             if prt:
                 prt.write('{N} IDs in loaded association branch, {NS}\n'.format(N=len(id2gos), NS=nspc))
             return id2gos
-        if prt and self.godag is None:
+        if self.godag is None:
             logging.warning('%s(..., godag=None).get_id2gos: GODAG is None. IGNORING namespace(%s)\n',
                             type(self).__name__, namespace)
         id2gos = self._get_id2gos(self.associations, **kws)

--- a/goatools/anno/init/reader_gaf.py
+++ b/goatools/anno/init/reader_gaf.py
@@ -185,7 +185,7 @@ class GafData:
         self.illegal_lines = cx.defaultdict(list)  # GAF lines that are missing information (missing taxon)
 
     def _init_is_long(self, ver, fallback=LATEST_GAF_VERSION):
-        """If the GAF version is >2.0, the GAF format is the long format (2 more cols)"""
+        """If the GAF version is >= 2.0, the GAF format is the long format (2 more cols)"""
         if ver is not None:
             return ver[0] == '2'
         print('\n**WARNING: NO VERSION LINE FOUND IN GAF FILE. USING:')


### PR DESCRIPTION
When running `map_to_slim.py` we get an error string:

```
**ERROR IdToGosReader(..., godag=None).get_id2gos: GODAG is None!. IGNORING namespace(BP)
```

Since this does not impact end results. I changed the display to a **warning** instead, with the appropriate logging level which can be a bit friendlier to the users:

```
WARNING:root:IdToGosReader.get_id2gos: GODAG is None. IGNORING namespace(BP). If you are running `map_to_slim.py`, this warning can be ignored.
```