### PR TITLE
Fixed bug in write_hierarchy_base.py

### DIFF
--- a/goatools/gosubdag/rpt/write_hierarchy.py
+++ b/goatools/gosubdag/rpt/write_hierarchy.py
@@ -14,7 +14,9 @@ class WrHierGO:
     """Write hierarchy object."""
 
     kws_dct = set(['max_indent', 'include_only', 'item_marks', 'dash_len', 'sortby'])
-    kws_set = set(['no_indent', 'concise'])
+    kws_set = set(['no_indent', 'concise' , 'no_dup']) 
+    # Note: no_dup overrides concise such that if no_dup=True the value of
+    # concise is ignored.
     kws_all = kws_dct.union(kws_set)
 
     def __init__(self, gosubdag, **kws):
@@ -91,6 +93,7 @@ class WrHierGO:
                 'include_only': self.usrdct.get('include_only'),
                 'item_marks': self.usrdct.get('item_marks', {}),
                 'concise_prt': 'concise' in self.usrset,
+                'no_dup_prt': 'no_dup' in self.usrset, # If no_dup_prt=True, the value of concise_prt will be ignored.
                 'indent': 'no_indent' not in self.usrset,
                 'dash_len': self.usrdct.get('dash_len', 6),
                 'sortby': self.usrdct.get('sortby')

--- a/goatools/rpt/write_hierarchy_base.py
+++ b/goatools/rpt/write_hierarchy_base.py
@@ -38,6 +38,12 @@ class WrHierPrt(object):
         if self.include_only and item_id not in self.include_only:
             return
 
+        # Do not print hierarchy from this item downwards if the item has already been printed.
+        no_repeat = self.concise_prt and item_id in self.items_printed
+        if no_repeat:
+            return
+
+        # Print content
         obj = self.id2obj[item_id]
         # Optionally space the branches for readability
         if self.space_branches:
@@ -48,8 +54,6 @@ class WrHierPrt(object):
             self.prt.write('{MARK} '.format(
                 MARK=self.item_marks.get(item_id, self.mark_dflt)))
 
-        no_repeat = self.concise_prt and item_id in self.items_printed
-        # Print content
         dashes = self._str_dash(depth, no_repeat, obj)
         if self.do_prtfmt:
             self._prtfmt(item_id, dashes)
@@ -57,9 +61,7 @@ class WrHierPrt(object):
             self._prtstr(obj, dashes)
         self.items_printed.add(item_id)
         self.items_list.append(item_id)
-        # Do not print hierarchy below this turn if it has already been printed
-        if no_repeat:
-            return
+        
         depth += 1
         if self.max_indent is not None and depth > self.max_indent:
             return

--- a/goatools/rpt/write_hierarchy_base.py
+++ b/goatools/rpt/write_hierarchy_base.py
@@ -38,12 +38,6 @@ class WrHierPrt(object):
         if self.include_only and item_id not in self.include_only:
             return
 
-        # Do not print hierarchy from this item downwards if the item has already been printed.
-        no_repeat = self.concise_prt and item_id in self.items_printed
-        if no_repeat:
-            return
-
-        # Print content
         obj = self.id2obj[item_id]
         # Optionally space the branches for readability
         if self.space_branches:
@@ -54,6 +48,8 @@ class WrHierPrt(object):
             self.prt.write('{MARK} '.format(
                 MARK=self.item_marks.get(item_id, self.mark_dflt)))
 
+        no_repeat = self.concise_prt and item_id in self.items_printed
+        # Print content
         dashes = self._str_dash(depth, no_repeat, obj)
         if self.do_prtfmt:
             self._prtfmt(item_id, dashes)
@@ -61,7 +57,9 @@ class WrHierPrt(object):
             self._prtstr(obj, dashes)
         self.items_printed.add(item_id)
         self.items_list.append(item_id)
-        
+        # Do not print hierarchy below this turn if it has already been printed
+        if no_repeat:
+            return
         depth += 1
         if self.max_indent is not None and depth > self.max_indent:
             return

--- a/goatools/rpt/write_hierarchy_base.py
+++ b/goatools/rpt/write_hierarchy_base.py
@@ -22,6 +22,7 @@ class WrHierPrt(object):
         self.item_marks = self._init_item_marks(cfg.get('item_marks'))
         self.mark_dflt = cfg.get('mark_default', ' ')
         self.concise_prt = cfg.get('concise_prt', False)
+        self.no_dup_prt = cfg.get('no_dup_prt', False)
         self.indent = cfg.get('indent', True)
         self.space_branches = cfg.get('space_branches', False)
         self.sortby = cfg.get('sortby')
@@ -38,6 +39,18 @@ class WrHierPrt(object):
         if self.include_only and item_id not in self.include_only:
             return
 
+        # Do not print hierarchy from this item downwards if hierarchy is being
+        # printed as a flat list - that is, with strictly no duplications - and the item has 
+        # already been printed.
+        # Note that, by default, no_dup_prt is False. *However*, if it is set to
+        # True then this will overide the setting for concise_prt. That is,
+        # regardless of whether concise_prt is True or False, the hierarchy will
+        # be printed as a flat list with strictly no duplications.
+        no_repeat_strict = self.no_dup_prt and item_id in self.items_printed
+        if no_repeat_strict:
+            return
+
+        # Print content
         obj = self.id2obj[item_id]
         # Optionally space the branches for readability
         if self.space_branches:
@@ -57,9 +70,11 @@ class WrHierPrt(object):
             self._prtstr(obj, dashes)
         self.items_printed.add(item_id)
         self.items_list.append(item_id)
-        # Do not print hierarchy below this turn if it has already been printed
+        # Do not print hierarchy below this turn if it has already been printed,
+        # and if concise printing is on (concise_prt = True)
         if no_repeat:
             return
+        
         depth += 1
         if self.max_indent is not None and depth > self.max_indent:
             return

--- a/tests/test_write_hier.py
+++ b/tests/test_write_hier.py
@@ -24,16 +24,11 @@ def write_hier_all(gosubdag, out):
 
 def write_hier_norep(gosubdag, out):
     """Shortens hierarchy report by only printing branches once.
-
          Prints the 'entire hierarchy' of GO:0000005 the 1st time seen:
-
            ---     1 GO:0000005    L-02    D-02
            ----     0 GO:0000010   L-03    D-04
-
          Prints just GO:0000005 (ommit child GO:10) the 2nd time seen:
-
            ===     1 GO:0000005    L-02    D-02
-
          '=' is used in hierarchy mark to indicate that the pathes
              below the marked term have already been printed.
     """
@@ -46,6 +41,30 @@ def write_hier_norep(gosubdag, out):
                            'GO:0000005', 'GO:0000006', 'GO:0000008', 'GO:0000009',
                            'GO:0000010']
 
+
+def write_hier_nodups(gosubdag, out):
+    """Flattens hierarchy report to a list by printing items only once, i.e. with no duplications."""
+    out.write('\nTEST ALL: Print items just once:\n')
+    objwr = WrHierGO(gosubdag, no_dup=True, sortby=lambda o: o.item_id)
+    gos_printed = objwr.prt_hier_down("GO:0000001", out)
+    assert set(gos_printed) == set(objwr.gosubdag.go2nt)
+    assert gos_printed == ['GO:0000001', 'GO:0000002', 'GO:0000005', 'GO:0000010',
+                           'GO:0000003', 'GO:0000004', 'GO:0000007', 'GO:0000009',
+                           'GO:0000006', 'GO:0000008']
+    out.write('\nTEST ALL: Check no_dup=True overrides explicit concise=False:\n')
+    objwr_2 = WrHierGO(gosubdag, no_dup=True, concise=False, sortby=lambda o: o.item_id)
+    gos_printed_2 = objwr_2.prt_hier_down("GO:0000001", out)
+    assert set(gos_printed_2) == set(objwr_2.gosubdag.go2nt)
+    assert gos_printed_2 == ['GO:0000001', 'GO:0000002', 'GO:0000005', 'GO:0000010',
+                           'GO:0000003', 'GO:0000004', 'GO:0000007', 'GO:0000009',
+                           'GO:0000006', 'GO:0000008']
+    out.write('\nTEST ALL: Check no_dup=True overrides concise=True:\n')
+    objwr_3 = WrHierGO(gosubdag, no_dup=True, concise=True, sortby=lambda o: o.item_id)
+    gos_printed_3 = objwr_3.prt_hier_down("GO:0000001", out)
+    assert set(gos_printed_3) == set(objwr_3.gosubdag.go2nt)
+    assert gos_printed_3 == ['GO:0000001', 'GO:0000002', 'GO:0000005', 'GO:0000010',
+                           'GO:0000003', 'GO:0000004', 'GO:0000007', 'GO:0000009',
+                           'GO:0000006', 'GO:0000008']
 
 def write_hier_lim(gosubdag, out):
     """Limits hierarchy list to GO Terms specified by user."""
@@ -105,6 +124,7 @@ def test_all():
     out = sys.stdout
     write_hier_all(gosubdag, out)
     write_hier_norep(gosubdag, out)
+    write_hier_nodups(gosubdag, out)
     write_hier_lim(gosubdag, out)
     write_hier_mrk_lst(gosubdag, out)
     write_hier_mrk_dct(gosubdag, out)


### PR DESCRIPTION
In the previous version of the code, if a term had already been printed, then the hierarchy below it would not be printed again, however the term itself would be. While this stopped whole hierarchies being duplicated, it did not prevent some terms being printed more than once. In this version of the code, the conditional testing for no repetition (if no_repeat:) is moved to the top of function prt_hier_rec, which fixes this bug; this also has the bonus effect of preventing code being run that does not need to run.