### PR TITLE
Allow arbitrary Aspect codes

### DIFF
--- a/goatools/anno/init/utils.py
+++ b/goatools/anno/init/utils.py
@@ -10,4 +10,5 @@ def get_date_yyyymmdd(yyyymmdd):
     """Return datetime.date given string."""
     return date(int(yyyymmdd[:4]), int(yyyymmdd[4:6], base=10), int(yyyymmdd[6:], base=10))
 
+
 # Copyright (C) 2016-2019, DV Klopfenstein, H Tang. All rights reserved.


### PR DESCRIPTION
This PR addresses [issue 228](https://github.com/tanghaibao/goatools/issues/228) regarding the inability to parse GAF files containing Aspect codes from ontologies other than GO, even if the rest of the file is correctly formatted. 