### PR TITLE
Handle EC.5.3.3.21

### DIFF
--- a/goatools/godag/obo_optional_attributes.py
+++ b/goatools/godag/obo_optional_attributes.py
@@ -138,8 +138,10 @@ class OboOptionalAttrs:
             if match:
                 s = match.group(1)
                 rec.xref.add(s.replace(" ", ""))
-            else:  # occasionally just 'EC 2.7.1.190'
-                rec.xref.add(s.replace(" ", ":"))
+            else:
+                # occasionally just 'EC 2.7.1.190'
+                # or 'EC.5.3.3.21'
+                rec.xref.add(re.sub(r"^EC[ \.]", "EC:", s))
 
         fnc_updaterec.cmpd = re.compile(r"^(\S+:\s*\S+)\b(.*)$")
         return fnc_chkline, fnc_updaterec


### PR DESCRIPTION
New version of `go-basic.obo` (as of Jan-18-2022) contains the following stanza:

```
xref: EC.5.3.3.21
```

Which the parser fails to validate. Cleansing the input prior to validation.