### PR TITLE
Better support for obsolete terms (#276, thanks @Maxim-Karpov)

### DIFF
--- a/goatools/anno/annoreader_base.py
+++ b/goatools/anno/annoreader_base.py
@@ -352,8 +352,8 @@ class AnnoReaderBase(object):
             assert isinstance(
                 qual, set
             ), f"{self.name}: QUALIFIER MUST BE A LIST: {ntd}"
-            assert qual != set([""]), ntd
-            assert qual != set(["-"]), ntd
+            assert qual != {""}, ntd
+            assert qual != {"-"}, ntd
             assert "always" not in qual, "SPEC SAID IT WOULD BE THERE"
 
     def chk_godag(self):

--- a/goatools/anno/annoreader_base.py
+++ b/goatools/anno/annoreader_base.py
@@ -11,33 +11,40 @@ from goatools.anno.opts import AnnoOptions
 from goatools.godag.consts import NAMESPACE2NS
 from goatools.gosubdag.go_tasks import get_go2parents_go2obj
 
-__copyright__ = "Copyright (C) 2016-present, DV Klopfenstein, H Tang. All rights reserved."
+__copyright__ = (
+    "Copyright (C) 2016-present, DV Klopfenstein, H Tang. All rights reserved."
+)
 __author__ = "DV Klopfenstein"
 
 
 # pylint: disable=useless-object-inheritance,too-many-public-methods
 class AnnoReaderBase(object):
     """Reads a Gene Association File. Returns a Python object."""
+
     # pylint: disable=broad-except,line-too-long,too-many-instance-attributes
 
     tic = timeit.default_timer()
 
     # Expected values for a Qualifier
-    exp_qualifiers = set([
-        # Seen in both GAF and gene2go
-        'not', 'contributes_to', 'colocalizes_with',
-    ])
+    exp_qualifiers = set(
+        [
+            # Seen in both GAF and gene2go
+            "not",
+            "contributes_to",
+            "colocalizes_with",
+        ]
+    )
 
-    valid_formats = {'gpad', 'gaf', 'gene2go', 'id2gos'}
+    valid_formats = {"gpad", "gaf", "gene2go", "id2gos"}
 
-    exp_nss = set(['BP', 'MF', 'CC'])
+    exp_nss = set(["BP", "MF", "CC"])
 
     def __init__(self, name, filename=None, **kws):
         # kws: allow_missing_symbol
         self.name = name  # name is one of valid_formats
         self.filename = filename
-        self.godag = kws.get('godag')
-        self.namespaces = kws.get('namespaces')
+        self.godag = kws.get("godag")
+        self.namespaces = kws.get("namespaces")
         self.evobj = EvidenceCodes()
         # Read anotation file, store namedtuples:
         #     Gene2GoReader(filename=None, taxids=None):
@@ -52,10 +59,11 @@ class AnnoReaderBase(object):
 
     def get_desc(self):
         """Get description"""
-        return '{NAME} {NSs} {GODAG}'.format(
+        return "{NAME} {NSs} {GODAG}".format(
             NAME=self.name,
-            NSs='' if self.namespaces is None else ','.join(self.namespaces),
-            GODAG='' if self.godag is None else 'godag')
+            NSs="" if self.namespaces is None else ",".join(self.namespaces),
+            GODAG="" if self.godag is None else "godag",
+        )
 
     # pylint: disable=unused-argument
     def get_associations(self, taxid=None):
@@ -79,7 +87,10 @@ class AnnoReaderBase(object):
     # Arg, taxid, is used by NCBI's annotations, but not by gpad, gaf, etc.
     def get_ns2assc(self, taxid=None, **kws):
         """Return given associations into 3 (BP, MF, CC) dicts, id2gos"""
-        return {ns:self._get_id2gos(nts, **kws) for ns, nts in self.get_ns2ntsanno().items()}
+        return {
+            ns: self._get_id2gos(nts, **kws)
+            for ns, nts in self.get_ns2ntsanno().items()
+        }
 
     # pylint: disable=unused-argument
     # Arg, taxid, is used by NCBI's annotations, but not by gpad, gaf, etc.
@@ -90,9 +101,12 @@ class AnnoReaderBase(object):
     # Used by gpad, gaf, etc., but not used by NCBI's annotation reader
     def _get_ns2ntsanno(self, annotations):
         """Split list of annotations into 3 lists: BP, MF, CC"""
-        if self.name in {'gpad', 'id2gos'}:
-            assert self.godag is not None, "{T}: LOAD godag TO USE {C}::ns2ntsanno".format(
-                C=self.__class__.__name__, T=self.name)
+        if self.name in {"gpad", "id2gos"}:
+            assert (
+                self.godag is not None
+            ), "{T}: LOAD godag TO USE {C}::ns2ntsanno".format(
+                C=self.__class__.__name__, T=self.name
+            )
         ns2nts = cx.defaultdict(list)
         if self.godag:
             s_godag = self.godag
@@ -102,7 +116,7 @@ class AnnoReaderBase(object):
         else:
             for nta in annotations:
                 ns2nts[nta.NS].append(nta)
-        return {ns:ns2nts[ns] for ns in ns2nts}
+        return {ns: ns2nts[ns] for ns in ns2nts}
 
     def get_id2gos_nss(self, **kws):
         """Return all associations in a dict, id2gos, regardless of namespace"""
@@ -115,14 +129,21 @@ class AnnoReaderBase(object):
             nspc, assoc = self._get_1ns_assn(namespace)
             id2gos = self._get_id2gos(assoc, **kws)
             if prt:
-                prt.write('{N} IDs in loaded association branch, {NS}\n'.format(N=len(id2gos), NS=nspc))
+                prt.write(
+                    "{N} IDs in loaded association branch, {NS}\n".format(
+                        N=len(id2gos), NS=nspc
+                    )
+                )
             return id2gos
         if prt and self.godag is None:
-            logging.warning('%s.get_id2gos: GODAG is None. IGNORING namespace(%s). If you are running `map_to_slim.py`, this warning can be ignored.',
-                            type(self).__name__, namespace)
+            logging.warning(
+                "%s.get_id2gos: GODAG is None. IGNORING namespace(%s). If you are running `map_to_slim.py`, this warning can be ignored.",
+                type(self).__name__,
+                namespace,
+            )
         id2gos = self._get_id2gos(self.associations, **kws)
         if prt:
-            prt.write('{N} IDs in all associations\n'.format(N=len(id2gos)))
+            prt.write("{N} IDs in all associations\n".format(N=len(id2gos)))
         return id2gos
 
     def _get_1ns_assn(self, namespace_usr):
@@ -130,7 +151,11 @@ class AnnoReaderBase(object):
         # If all namespaces were loaded
         if self.namespaces is None:
             # Return user-specified namespace, if provided. Otherwise BP
-            nspc = self._get_biggest_namespace() if namespace_usr is None else namespace_usr
+            nspc = (
+                self._get_biggest_namespace()
+                if namespace_usr is None
+                else namespace_usr
+            )
             # Return one namespace
             if nspc in set(NAMESPACE2NS.values()):
                 return nspc, [nt for nt in self.associations if nt.NS == nspc]
@@ -140,12 +165,18 @@ class AnnoReaderBase(object):
         if len(self.namespaces) == 1:
             nspc = next(iter(self.namespaces))
             if namespace_usr is not None and nspc != namespace_usr:
-                print('**WARNING: IGNORING {ns}; ONLY {NS} WAS LOADED'.format(
-                    ns=namespace_usr, NS=nspc))
+                print(
+                    "**WARNING: IGNORING {ns}; ONLY {NS} WAS LOADED".format(
+                        ns=namespace_usr, NS=nspc
+                    )
+                )
             return nspc, self.associations
         if namespace_usr is None:
-            print('**ERROR get_id2gos: GODAG NOT LOADED. USING: {NSs}'.format(
-                NSs=' '.join(sorted(self.namespaces))))
+            print(
+                "**ERROR get_id2gos: GODAG NOT LOADED. USING: {NSs}".format(
+                    NSs=" ".join(sorted(self.namespaces))
+                )
+            )
         return namespace_usr, self.associations
 
     def _get_biggest_namespace(self):
@@ -155,10 +186,19 @@ class AnnoReaderBase(object):
 
     def has_ns(self):
         """Return True if namespace field, NS exists on annotation namedtuples"""
-        assert self.associations, 'NO ASSOCIATIONS IN file({}): {}'.format(self.filename, self.associations)
-        return hasattr(next(iter(self.associations)), 'NS')
+        assert self.associations, "NO ASSOCIATIONS IN file({}): {}".format(
+            self.filename, self.associations
+        )
+        return hasattr(next(iter(self.associations)), "NS")
 
-    def _get_id2gos(self, ntannos_usr, propagate_counts=False, relationships=None, prt=sys.stdout, **kws):
+    def _get_id2gos(
+        self,
+        ntannos_usr,
+        propagate_counts=False,
+        relationships=None,
+        prt=sys.stdout,
+        **kws
+    ):
         """Return given ntannos_usr in a dict, id2gos"""
         options = AnnoOptions(self.evobj, **kws)
         # Default reduction is to remove. For all options, see goatools/anno/opts.py:
@@ -166,7 +206,9 @@ class AnnoReaderBase(object):
         #   * Qualifiers contain NOT
         ntannos_indag = self._get_anno_in_dag(ntannos_usr)
         ntannos_m = self.reduce_annotations(ntannos_indag, options)
-        dbid2goids = self.get_dbid2goids(ntannos_m, propagate_counts, relationships, prt)
+        dbid2goids = self.get_dbid2goids(
+            ntannos_m, propagate_counts, relationships, prt
+        )
         if options.b_geneid2gos:
             return dbid2goids
         # if not a2bs:
@@ -205,21 +247,25 @@ class AnnoReaderBase(object):
     @staticmethod
     def _prt_qualifiers(associations, prt=sys.stdout):
         """Print Qualifiers found in the annotations.
-           QUALIFIERS:
-                1,462 colocalizes_with
-                1,454 contributes_to
-                1,157 not
-                   13 not colocalizes_with   (TBD: CHK - Seen in gene2go, but not gafs)
-                    4 not contributes_to     (TBD: CHK - Seen in gene2go, but not gafs)
+        QUALIFIERS:
+             1,462 colocalizes_with
+             1,454 contributes_to
+             1,157 not
+                13 not colocalizes_with   (TBD: CHK - Seen in gene2go, but not gafs)
+                 4 not contributes_to     (TBD: CHK - Seen in gene2go, but not gafs)
         """
-        prt.write('QUALIFIERS:\n')
-        for fld, cnt in cx.Counter(q for nt in associations for q in nt.Qualifier).most_common():
-            prt.write('    {N:6,} {FLD}\n'.format(N=cnt, FLD=fld))
+        prt.write("QUALIFIERS:\n")
+        for fld, cnt in cx.Counter(
+            q for nt in associations for q in nt.Qualifier
+        ).most_common():
+            prt.write("    {N:6,} {FLD}\n".format(N=cnt, FLD=fld))
 
     def reduce_annotations(self, annotations, options):
         """Reduce annotations to ones used to identify enrichment (normally exclude ND and NOT)."""
         getfnc_qual_ev = options.getfnc_qual_ev()
-        return [nt for nt in annotations if getfnc_qual_ev(nt.Qualifier, nt.Evidence_Code)]
+        return [
+            nt for nt in annotations if getfnc_qual_ev(nt.Qualifier, nt.Evidence_Code)
+        ]
 
     @staticmethod
     def update_association(assc_goidsets, go2ancestors, prt=sys.stdout):
@@ -239,13 +285,18 @@ class AnnoReaderBase(object):
         # Get GO IDs in annotations that are in GO DAG
         goids_avail = set(_godag)
         goids_missing = self._rpt_goids_notfound(goids_assoc_usr, goids_avail)
-        goids_assoc_cur = goids_assoc_usr.intersection(goids_avail).difference(goids_missing)
+        goids_assoc_cur = goids_assoc_usr.intersection(goids_avail).difference(
+            goids_missing
+        )
         # Get GO Term for each current GO ID in the annotations
-        _go2obj_assc = {go:_godag[go] for go in goids_assoc_cur}
+        _go2obj_assc = {go: _godag[go] for go in goids_assoc_cur}
         go2ancestors = get_go2parents_go2obj(_go2obj_assc, relationships, prt)
         if prt:
-            prt.write('{N} GO IDs -> {M} go2ancestors\n'.format(
-                N=len(goids_avail), M=len(go2ancestors)))
+            prt.write(
+                "{N} GO IDs -> {M} go2ancestors\n".format(
+                    N=len(goids_avail), M=len(go2ancestors)
+                )
+            )
         return go2ancestors
 
     @staticmethod
@@ -253,11 +304,16 @@ class AnnoReaderBase(object):
         """Report the number of GO IDs in the association, but not in the GODAG"""
         goids_missing = goids_assoc_all.difference(goids_avail)
         if goids_missing:
-            print("{N} GO IDs NOT FOUND IN ASSOCIATION: {GOs}".format(
-                N=len(goids_missing), GOs=" ".join(sorted(goids_missing))))
+            print(
+                "{N} GO IDs NOT FOUND IN ASSOCIATION: {GOs}".format(
+                    N=len(goids_missing), GOs=" ".join(sorted(goids_missing))
+                )
+            )
         return goids_missing
 
-    def get_dbid2goids(self, ntannos, propagate_counts=False, relationships=None, prt=sys.stdout):
+    def get_dbid2goids(
+        self, ntannos, propagate_counts=False, relationships=None, prt=sys.stdout
+    ):
         """Return gene2go data for user-specified taxids."""
         if propagate_counts:
             return self._get_dbid2goids_p1(ntannos, relationships, prt)
@@ -299,8 +355,8 @@ class AnnoReaderBase(object):
         if tic is None:
             tic = self.tic
         now = timeit.default_timer()
-        hms = str(datetime.timedelta(seconds=(now-tic)))
-        prt.write('{HMS}: {MSG}\n'.format(HMS=hms, MSG=msg))
+        hms = str(datetime.timedelta(seconds=now - tic))
+        prt.write("{HMS}: {MSG}\n".format(HMS=hms, MSG=msg))
         return now
 
     def chk_associations(self, fout_err=None):
@@ -310,7 +366,7 @@ class AnnoReaderBase(object):
 
     def nts_ev_nd(self):
         """Get annotations where Evidence_code == 'ND' (No biological data)"""
-        return [nt for nt in self.associations if nt.Evidence_Code == 'ND']
+        return [nt for nt in self.associations if nt.Evidence_Code == "ND"]
 
     def nts_qual_not(self):
         """Get annotations having Qualifiers containing NOT"""
@@ -318,30 +374,33 @@ class AnnoReaderBase(object):
 
     def chk_qualifiers(self):
         """Check format of qualifier"""
-        if self.name == 'id2gos':
+        if self.name == "id2gos":
             return
         for ntd in self.associations:
-            # print(ntd)
             qual = ntd.Qualifier
-            assert isinstance(qual, set), '{NAME}: QUALIFIER MUST BE A LIST: {NT}'.format(
-                NAME=self.name, NT=ntd)
-            assert qual != set(['']), ntd
-            assert qual != set(['-']), ntd
-            assert 'always' not in qual, 'SPEC SAID IT WOULD BE THERE'
+            assert isinstance(
+                qual, set
+            ), "{NAME}: QUALIFIER MUST BE A LIST: {NT}".format(NAME=self.name, NT=ntd)
+            assert qual != set([""]), ntd
+            assert qual != set(["-"]), ntd
+            assert "always" not in qual, "SPEC SAID IT WOULD BE THERE"
 
     def chk_godag(self):
         """Check that a GODag was loaded"""
         if not self.godag:
-            raise RuntimeError('{CLS} MUST INCLUDE GODag: {CLS}(file.anno, godag=godag)'.format(
-                CLS=self.__class__.__name__))
+            raise RuntimeError(
+                "{CLS} MUST INCLUDE GODag: {CLS}(file.anno, godag=godag)".format(
+                    CLS=self.__class__.__name__
+                )
+            )
 
     @staticmethod
     def _has_not_qual(ntd):
         """Return True if the qualifiers contain a 'NOT'"""
         for qual in ntd.Qualifier:
-            if 'not' in qual:
+            if "not" in qual:
                 return True
-            if 'NOT' in qual:
+            if "NOT" in qual:
                 return True
         return False
 
@@ -349,7 +408,7 @@ class AnnoReaderBase(object):
         """Print the number of taxids stored."""
         num_annos = len(self.associations)
         # 792,891 annotations for 3 taxids stored: 10090 7227 9606
-        prt.write('{A:8,} annotations\n'.format(A=num_annos))
+        prt.write("{A:8,} annotations\n".format(A=num_annos))
 
 
 # Copyright (C) 2016-present, DV Klopfenstein, H Tang. All rights reserved."

--- a/goatools/anno/annoreader_base.py
+++ b/goatools/anno/annoreader_base.py
@@ -36,8 +36,7 @@ class AnnoReaderBase(object):
     )
 
     valid_formats = {"gpad", "gaf", "gene2go", "id2gos"}
-
-    exp_nss = set(["BP", "MF", "CC"])
+    exp_nss = {"BP", "MF", "CC"}
 
     def __init__(self, name, filename=None, **kws):
         # kws: allow_missing_symbol
@@ -46,15 +45,10 @@ class AnnoReaderBase(object):
         self.godag = kws.get("godag")
         self.namespaces = kws.get("namespaces")
         self.evobj = EvidenceCodes()
-        # Read anotation file, store namedtuples:
-        #     Gene2GoReader(filename=None, taxids=None):
-        #     GafReader(filename=None, hdr_only=False, prt=sys.stdout, allow_missing_symbol=False):
-        #     GpadReader(filename=None, hdr_only=False):
         self.hdr = None
         self.datobj = None
         # pylint: disable=no-member
         self.associations = self._init_associations(filename, **kws)
-        # assert self.associations, 'NO ANNOTATIONS FOUND: {ANNO}'.format(ANNO=filename)
         assert self.namespaces is None or isinstance(self.namespaces, set)
 
     def get_desc(self):

--- a/goatools/anno/idtogos_reader.py
+++ b/goatools/anno/idtogos_reader.py
@@ -11,25 +11,33 @@ __author__ = "DV Klopfenstein"
 class IdToGosReader(AnnoReaderBase):
     """Reads a Annotation File in text format with data in id2gos line"""
 
-    exp_kws = {'godag', 'namespaces'}
+    exp_kws = {"godag", "namespaces", "obsolete"}
 
     def __init__(self, filename=None, **kws):
         self.id2gos = None  # ID to GO ID set as loaded from annotations file
-        super(IdToGosReader, self).__init__('id2gos', filename,
-                                            godag=kws.get('godag'),
-                                            namespaces=kws.get('namespaces'))
+        super(IdToGosReader, self).__init__(
+            "id2gos",
+            filename,
+            godag=kws.get("godag"),
+            namespaces=kws.get("namespaces"),
+            obsolete=kws.get("obsolete"),
+        )
 
     @staticmethod
     def wr_id2gos(fout_txt, id2gos):
         """Write annotations into a text file"""
-        with open(fout_txt, 'w') as prt:
+        with open(fout_txt, "w") as prt:
             for geneid, goset in sorted(id2gos.items()):
-                prt.write('{GENE}\t{GOs}\n'.format(GENE=geneid, GOs=';'.join(sorted(goset))))
-        print('  {N} annotations WROTE: {TXT}'.format(N=len(id2gos), TXT=fout_txt))
+                prt.write(
+                    "{GENE}\t{GOs}\n".format(GENE=geneid, GOs=";".join(sorted(goset)))
+                )
+        print("  {N} annotations WROTE: {TXT}".format(N=len(id2gos), TXT=fout_txt))
 
     def prt_summary_anno2ev(self, prt=sys.stdout):
         """Print a summary of all Evidence Codes seen in annotations"""
-        prt.write('**NOTE: No evidence codes in associations: {F}\n'.format(F=self.filename))
+        prt.write(
+            "**NOTE: No evidence codes in associations: {F}\n".format(F=self.filename)
+        )
 
     # pylint: disable=unused-argument
     def reduce_annotations(self, associations, options):
@@ -46,7 +54,7 @@ class IdToGosReader(AnnoReaderBase):
 
     def _init_associations(self, fin_anno, **kws):
         """Read annotation file and store a list of namedtuples."""
-        ini = InitAssc(fin_anno, kws['godag'], kws['namespaces'])
+        ini = InitAssc(fin_anno, kws["godag"], kws["namespaces"], kws["obsolete"])
         self.id2gos = ini.id2gos
         return ini.nts
 

--- a/goatools/anno/idtogos_reader.py
+++ b/goatools/anno/idtogos_reader.py
@@ -31,13 +31,11 @@ class IdToGosReader(AnnoReaderBase):
                 prt.write(
                     "{GENE}\t{GOs}\n".format(GENE=geneid, GOs=";".join(sorted(goset)))
                 )
-        print("  {N} annotations WROTE: {TXT}".format(N=len(id2gos), TXT=fout_txt))
+        print(f"  {len(id2gos)} annotations WROTE: {fout_txt}")
 
     def prt_summary_anno2ev(self, prt=sys.stdout):
         """Print a summary of all Evidence Codes seen in annotations"""
-        prt.write(
-            "**NOTE: No evidence codes in associations: {F}\n".format(F=self.filename)
-        )
+        prt.write(f"**NOTE: No evidence codes in associations: {self.filename}\n")
 
     # pylint: disable=unused-argument
     def reduce_annotations(self, associations, options):

--- a/goatools/anno/init/reader_idtogos.py
+++ b/goatools/anno/init/reader_idtogos.py
@@ -72,13 +72,18 @@ class InitAssc:
                             to_add.add(goid)
                         elif self.obsolete == "replace":
                             to_replace = set()
-                            if "replaced_by" in goobj.__dict__:
-                                to_replace |= set(goobj.replaced_by)
+                            if "replaced_by" in goobj.__dict__ and goobj.replaced_by:
+                                to_replace |= set(goobj.replaced_by.split(","))
                             if "consider" in goobj.__dict__:
-                                to_replace |= set(goobj.consider)
-                            prt.write(
-                                f"**WARNING: {goid} obsolete in DAG, replaced by {to_replace}\n"
-                            )
+                                to_replace |= goobj.consider
+                            if to_replace:
+                                prt.write(
+                                    f"**WARNING: {goid} obsolete in DAG, replaced by {to_replace}\n"
+                                )
+                            else:
+                                prt.write(
+                                    f"**WARNING: {goid} obsolete in DAG, no replacement\n"
+                                )
                             to_add |= to_replace
                         elif self.obsolete == "skip":
                             prt.write(f"**WARNING: {goid} obsolete in DAG, skipped\n")

--- a/goatools/anno/init/reader_idtogos.py
+++ b/goatools/anno/init/reader_idtogos.py
@@ -64,31 +64,33 @@ class InitAssc:
         for itemid, gos in self.id2gos.items():
             to_add = set()
             for goid in gos:
-                if goid in s_godag:
-                    goobj = s_godag[goid]
-                    if goobj.is_obsolete:
-                        if self.obsolete == "keep":
-                            prt.write(f"**WARNING: {goid} obsolete in DAG, kept\n")
-                            to_add.add(goid)
-                        elif self.obsolete == "replace":
-                            to_replace = set()
-                            if "replaced_by" in goobj.__dict__ and goobj.replaced_by:
-                                to_replace |= set(goobj.replaced_by.split(","))
-                            if "consider" in goobj.__dict__ and goobj.consider:
-                                to_replace |= goobj.consider
-                            if to_replace:
-                                prt.write(
-                                    f"**WARNING: {goid} obsolete in DAG, replaced by {to_replace}\n"
-                                )
-                            else:
-                                prt.write(
-                                    f"**WARNING: {goid} obsolete in DAG, no replacement\n"
-                                )
-                            to_add |= to_replace
-                        elif self.obsolete == "skip":
-                            prt.write(f"**WARNING: {goid} obsolete in DAG, skipped\n")
-                    else:
+                if goid not in s_godag:
+                    prt.write(f"**WARNING: {goid} NOT FOUND IN DAG\n")
+                    continue
+                goobj = s_godag[goid]
+                if goobj.is_obsolete:
+                    if self.obsolete == "keep":
+                        prt.write(f"**WARNING: {goid} obsolete in DAG, kept\n")
                         to_add.add(goid)
+                    elif self.obsolete == "replace":
+                        to_replace = set()
+                        if "replaced_by" in goobj.__dict__ and goobj.replaced_by:
+                            to_replace |= set(goobj.replaced_by.split(","))
+                        if "consider" in goobj.__dict__ and goobj.consider:
+                            to_replace |= goobj.consider
+                        if to_replace:
+                            prt.write(
+                                f"**WARNING: {goid} obsolete in DAG, replaced by {to_replace}\n"
+                            )
+                        else:
+                            prt.write(
+                                f"**WARNING: {goid} obsolete in DAG, no replacement\n"
+                            )
+                        to_add |= to_replace
+                    elif self.obsolete == "skip":
+                        prt.write(f"**WARNING: {goid} obsolete in DAG, skipped\n")
+                else:
+                    to_add.add(goid)
             for goid in to_add:
                 goobj = s_godag[goid]
                 namespace = goobj.namespace

--- a/goatools/anno/init/reader_idtogos.py
+++ b/goatools/anno/init/reader_idtogos.py
@@ -74,7 +74,7 @@ class InitAssc:
                             to_replace = set()
                             if "replaced_by" in goobj.__dict__ and goobj.replaced_by:
                                 to_replace |= set(goobj.replaced_by.split(","))
-                            if "consider" in goobj.__dict__:
+                            if "consider" in goobj.__dict__ and goobj.consider:
                                 to_replace |= goobj.consider
                             if to_replace:
                                 prt.write(

--- a/goatools/anno/init/reader_idtogos.py
+++ b/goatools/anno/init/reader_idtogos.py
@@ -71,11 +71,15 @@ class InitAssc:
                             prt.write(f"**WARNING: {goid} obsolete in DAG, kept\n")
                             to_add.add(goid)
                         elif self.obsolete == "replace":
-                            prt.write(f"**WARNING: {goid} obsolete in DAG, replaced\n")
+                            to_replace = set()
                             if "replaced_by" in goobj.__dict__:
-                                to_add |= set(goobj.replaced_by)
+                                to_replace |= set(goobj.replaced_by)
                             if "consider" in goobj.__dict__:
-                                to_add |= set(goobj.consider)
+                                to_replace |= set(goobj.consider)
+                            prt.write(
+                                f"**WARNING: {goid} obsolete in DAG, replaced by {to_replace}\n"
+                            )
+                            to_add |= to_replace
                         elif self.obsolete == "skip":
                             prt.write(f"**WARNING: {goid} obsolete in DAG, skipped\n")
                     else:

--- a/goatools/anno/init/reader_idtogos.py
+++ b/goatools/anno/init/reader_idtogos.py
@@ -6,7 +6,9 @@ import datetime
 import collections as cx
 from goatools.godag.consts import NAMESPACE2NS
 
-__copyright__ = "Copyright (C) 2016-present, DV Klopfenstein, H Tang. All rights reserved."
+__copyright__ = (
+    "Copyright (C) 2016-present, DV Klopfenstein, H Tang. All rights reserved."
+)
 __author__ = "DV Klopfenstein"
 
 
@@ -14,28 +16,32 @@ __author__ = "DV Klopfenstein"
 class InitAssc:
     """Initialize associations."""
 
-    flds = ['DB_ID', 'GO_ID']
+    flds = ["DB_ID", "GO_ID"]
 
-    def __init__(self, fin_anno, godag, namespaces):
+    def __init__(self, fin_anno, godag, namespaces, obsolete: str):
         tic = timeit.default_timer()
         self.godag = godag
+        self.obsolete = obsolete
         self.id2gos = self._init_id2gos(fin_anno)
         self.nts = self.init_associations(namespaces)
-        print('HMS:{HMS} {N:7,} annotations READ: {ANNO} {NSs}'.format(
-            N=len(self.nts), ANNO=fin_anno,
-            NSs=','.join(namespaces) if namespaces else '',
-            HMS=str(datetime.timedelta(seconds=(timeit.default_timer()-tic)))))
+        print(
+            "HMS:{HMS} {N:7,} annotations READ: {ANNO} {NSs}".format(
+                N=len(self.nts),
+                ANNO=fin_anno,
+                NSs=",".join(namespaces) if namespaces else "",
+                HMS=str(datetime.timedelta(seconds=timeit.default_timer() - tic)),
+            )
+        )
 
     def init_associations(self, namespaces):
         """Get a list of namedtuples, one for each annotation."""
-        # _get_b_all_nss(namespaces)
         nts = self._init_w_godag() if self.godag else self._init_dflt()
         if self.godag is None:
             if namespaces is not None:
                 # pylint: disable=superfluous-parens
-                print('**WARNING: GODAG NOT LOADED. IGNORING namespaces={NS}'.format(NS=namespaces))
+                print(f"**WARNING: GODAG NOT LOADED. IGNORING namespaces={namespaces}")
             return nts
-        if namespaces == {'BP', 'MF', 'CC'}:
+        if namespaces == {"BP", "MF", "CC"}:
             return nts
         if not namespaces:
             return nts
@@ -44,7 +50,7 @@ class InitAssc:
     def _init_dflt(self):
         """Get a list of namedtuples, one for each annotation."""
         nts = []
-        ntobj = cx.namedtuple('ntanno', self.flds)
+        ntobj = cx.namedtuple("ntanno", self.flds)
         for itemid, gos in self.id2gos.items():
             for goid in gos:
                 nts.append(ntobj(DB_ID=itemid, GO_ID=goid))
@@ -53,24 +59,35 @@ class InitAssc:
     def _init_w_godag(self, prt=stdout):
         """Get a list of namedtuples, one for each annotation."""
         nts = []
-        ntobj = cx.namedtuple('ntanno', self.flds + ['NS'])
+        ntobj = cx.namedtuple("ntanno", self.flds + ["NS"])
         s_godag = self.godag
-        not_found = set()
         for itemid, gos in self.id2gos.items():
+            to_add = set()
             for goid in gos:
                 if goid in s_godag:
                     goobj = s_godag[goid]
-                    namespace = goobj.namespace
-                    nspc = NAMESPACE2NS.get(namespace, namespace) if goobj else ''
-                    nts.append(ntobj(DB_ID=itemid, GO_ID=goid, NS=nspc))
-                else:
-                    not_found.add(goid)
-        for goid in sorted(not_found):
-            prt.write('**WARNING: {GO} NOT FOUND IN DAG\n'.format(GO=goid))
+                    if goobj.is_obsolete:
+                        if self.obsolete == "keep":
+                            prt.write(f"**WARNING: {goid} obsolete in DAG, kept\n")
+                            to_add.add(goid)
+                        elif self.obsolete == "replace":
+                            prt.write(f"**WARNING: {goid} obsolete in DAG, replaced\n")
+                            if "replaced_by" in goobj.__dict__:
+                                to_add |= set(goobj.replaced_by)
+                            if "consider" in goobj.__dict__:
+                                to_add |= set(goobj.consider)
+                        elif self.obsolete == "skip":
+                            prt.write(f"**WARNING: {goid} obsolete in DAG, skipped\n")
+                    else:
+                        to_add.add(goid)
+            for goid in to_add:
+                goobj = s_godag[goid]
+                namespace = goobj.namespace
+                nspc = NAMESPACE2NS.get(namespace, namespace) if goobj else ""
+                nts.append(ntobj(DB_ID=itemid, GO_ID=goid, NS=nspc))
         return nts
 
     @staticmethod
-    #### def read_associations(assoc_fn, no_top=False):
     def _init_id2gos(assoc_fn):  ##, no_top=False):
         """
         Reads a gene id go term association file. The format of the file
@@ -105,7 +122,7 @@ class InitAssc:
                 atoms = row.split()
                 if len(atoms) == 2:
                     gene_id, go_terms = atoms
-                elif len(atoms) > 2 and row.count('\t') == 1:
+                elif len(atoms) > 2 and row.count("\t") == 1:
                     gene_id, go_terms = row.split("\t")
                 else:
                     continue

--- a/goatools/cli/find_enrichment.py
+++ b/goatools/cli/find_enrichment.py
@@ -351,8 +351,11 @@ class GoeaCliFnc:
             read_sections(self.args.sections) if self.args.sections else None
         )
         godag_optional_attrs = self._get_optional_attrs()
-        self.godag = GODag(obo_file=self.args.obo, optional_attrs=godag_optional_attrs)
-        ## print('ARGS GoeaCliFnc ', self.args)
+        self.godag = GODag(
+            obo_file=self.args.obo,
+            optional_attrs=godag_optional_attrs,
+            load_obsolete=True,
+        )
         # GET: Gene2GoReader, GafReader, GpadReader, or IdToGosReader
         self.objanno = self._get_objanno(self.args.filenames[2])
         _study, _pop = self.rd_files(*self.args.filenames[:2])
@@ -377,6 +380,7 @@ class GoeaCliFnc:
             anno_type = self.args.annofmt if self.args.annofmt else "id2gos"
         # kws: namespaces taxid godag
         kws = self._get_kws_objanno(anno_type)
+        kws["obsolete"] = self.args.obsolete
         return get_objanno(assoc_fn, anno_type, **kws)
 
     def _get_ns(self):

--- a/goatools/cli/find_enrichment.py
+++ b/goatools/cli/find_enrichment.py
@@ -608,6 +608,8 @@ class GoeaCliFnc:
             return {
                 "relationship",
             }
+        if self.args.obsolete == "replace":
+            return {"replaced_by", "consider"}
         return None
 
     def _get_remove_goids(self):

--- a/goatools/cli/find_enrichment.py
+++ b/goatools/cli/find_enrichment.py
@@ -50,6 +50,7 @@ from goatools.grouper.sorter import Sorter
 from goatools.grouper.aart_geneproducts_all import AArtGeneProductSetsAll
 from goatools.grouper.wr_sections import WrSectionsTxt
 from goatools.grouper.wrxlsx import WrXlsxSortedGos
+
 OBJPRTRES = GoeaPrintFunctions()
 
 
@@ -63,96 +64,218 @@ class GoeaCliArgs:
     def _init_args(self):
         """Get enrichment arg parser."""
 
-        #pylint: disable=invalid-name
-        p = argparse.ArgumentParser(__doc__,
-                                    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        # pylint: disable=invalid-name
+        p = argparse.ArgumentParser(
+            __doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        )
 
-        p.add_argument('filenames', type=str, nargs=3,
-                       help='data/study data/population data/association')
-        p.add_argument('--annofmt', default=None, type=str,
-                       help=('Annotation file format. '
-                             'Not needed if type can be determined using filename'),
-                       choices=['gene2go', 'gaf', 'gpad', 'id2gos'])
-        p.add_argument('--taxid', default=9606, type=int,
-                       help="When using NCBI's gene2go annotation file, specify desired taxid")
-        p.add_argument('--alpha', default=0.05, type=float,
-                       help='Test-wise alpha for multiple testing')
-        p.add_argument('--pval', default=.05, type=float,
-                       help=('Only print results with uncorrected p-value < PVAL. '
-                             'Print all results, significant and otherwise, '
-                             'by setting --pval=1.0'))
-        p.add_argument('--pval_field', type=str,
-                       help='Only print results when PVAL_FIELD < PVAL.')
-        p.add_argument('--outfile', default=None, type=str,
-                       help='Write enrichment results into xlsx or tsv file')
-        p.add_argument('--ns', default='BP,MF,CC', type=str,
-                       help='Limit GOEA to specified branch categories. '
-                            'BP=Biological Process; '
-                            'MF=Molecular Function; '
-                            'CC=Cellular Component')
-        p.add_argument('--id2sym', default=None, type=str,
-                       help='ASCII file containing one geneid and its symbol per line')
-        p.add_argument('--sections', default=None, type=str,
-                       help=('Use sections file for printing grouped GOEA results. '
-                             'Example SECTIONS values:\n'
-                             'goatools.test_data.sections.gjoneska_pfenning \n'
-                             'goatools/test_data/sections/gjoneska_pfenning.py \n'
-                             'data/gjoneska_pfenning/sections_in.txt\n'))
-        p.add_argument('--outfile_detail', type=str,
-                       help=('Write enrichment results into a text file \n'
-                             'containing the following information: \n'
-                             '1) GOEA GO terms, grouped into sections \n\n'
-                             '2) List of genes and ASCII art showing section membership \n'
-                             '3) Detailed list of each gene and GO terms w/their P-values \n'))
-        p.add_argument('--compare', dest='compare', default=False,
-                       action='store_true',
-                       help="the population file as a comparison group. if this "
-                       "flag is specified, the population is used as the study "
-                       "plus the `population/comparison`")
-        p.add_argument('--ratio', dest='ratio', type=float, default=None,
-                       help="only show values where the difference between study "
-                       "and population ratios is greater than this. useful for "
-                       "excluding GO categories with small differences, but "
-                       "containing large numbers of genes. should be a value "
-                       "between 1 and 2. ")
-        p.add_argument('--prt_study_gos_only', default=False, action='store_true',
-                       help=('Print GO terms only if they are associated with study genes. '
-                             'This is useful if printng all GO results '
-                             'regardless of their significance (--pval=1.0). '))
-        p.add_argument('--indent', dest='indent', default=False,
-                       action='store_true', help="indent GO terms")
-        p.add_argument('--obo', default="go-basic.obo", type=str,
-                       help="Specifies location and name of the obo file")
-        p.add_argument('--no_propagate_counts', default=False, action='store_true',
-                       help="Do not propagate counts to parent terms")
+        p.add_argument(
+            "filenames",
+            type=str,
+            nargs=3,
+            help="data/study data/population data/association",
+        )
+        p.add_argument(
+            "--annofmt",
+            default=None,
+            type=str,
+            help=(
+                "Annotation file format. "
+                "Not needed if type can be determined using filename"
+            ),
+            choices=["gene2go", "gaf", "gpad", "id2gos"],
+        )
+        p.add_argument(
+            "--taxid",
+            default=9606,
+            type=int,
+            help="When using NCBI's gene2go annotation file, specify desired taxid",
+        )
+        p.add_argument(
+            "--alpha",
+            default=0.05,
+            type=float,
+            help="Test-wise alpha for multiple testing",
+        )
+        p.add_argument(
+            "--pval",
+            default=0.05,
+            type=float,
+            help=(
+                "Only print results with uncorrected p-value < PVAL. "
+                "Print all results, significant and otherwise, "
+                "by setting --pval=1.0"
+            ),
+        )
+        p.add_argument(
+            "--pval_field", type=str, help="Only print results when PVAL_FIELD < PVAL."
+        )
+        p.add_argument(
+            "--outfile",
+            default=None,
+            type=str,
+            help="Write enrichment results into xlsx or tsv file",
+        )
+        p.add_argument(
+            "--ns",
+            default="BP,MF,CC",
+            type=str,
+            help="Limit GOEA to specified branch categories. "
+            "BP=Biological Process; "
+            "MF=Molecular Function; "
+            "CC=Cellular Component",
+        )
+        p.add_argument(
+            "--id2sym",
+            default=None,
+            type=str,
+            help="ASCII file containing one geneid and its symbol per line",
+        )
+        p.add_argument(
+            "--sections",
+            default=None,
+            type=str,
+            help=(
+                "Use sections file for printing grouped GOEA results. "
+                "Example SECTIONS values:\n"
+                "goatools.test_data.sections.gjoneska_pfenning \n"
+                "goatools/test_data/sections/gjoneska_pfenning.py \n"
+                "data/gjoneska_pfenning/sections_in.txt\n"
+            ),
+        )
+        p.add_argument(
+            "--outfile_detail",
+            type=str,
+            help=(
+                "Write enrichment results into a text file \n"
+                "containing the following information: \n"
+                "1) GOEA GO terms, grouped into sections \n\n"
+                "2) List of genes and ASCII art showing section membership \n"
+                "3) Detailed list of each gene and GO terms w/their P-values \n"
+            ),
+        )
+        p.add_argument(
+            "--compare",
+            dest="compare",
+            default=False,
+            action="store_true",
+            help="the population file as a comparison group. if this "
+            "flag is specified, the population is used as the study "
+            "plus the `population/comparison`",
+        )
+        p.add_argument(
+            "--ratio",
+            dest="ratio",
+            type=float,
+            default=None,
+            help="only show values where the difference between study "
+            "and population ratios is greater than this. useful for "
+            "excluding GO categories with small differences, but "
+            "containing large numbers of genes. should be a value "
+            "between 1 and 2. ",
+        )
+        p.add_argument(
+            "--prt_study_gos_only",
+            default=False,
+            action="store_true",
+            help=(
+                "Print GO terms only if they are associated with study genes. "
+                "This is useful if printng all GO results "
+                "regardless of their significance (--pval=1.0). "
+            ),
+        )
+        p.add_argument(
+            "--indent",
+            dest="indent",
+            default=False,
+            action="store_true",
+            help="indent GO terms",
+        )
+        p.add_argument(
+            "--obo",
+            default="go-basic.obo",
+            type=str,
+            help="Specifies location and name of the obo file",
+        )
+        p.add_argument(
+            "--no_propagate_counts",
+            default=False,
+            action="store_true",
+            help="Do not propagate counts to parent terms",
+        )
         # no -r:   args.relationship == False
         # -r seen: args.relationship == True
-        p.add_argument('-r', '--relationship', action='store_true',
-                       help='Propagate counts up all relationships,')
+        p.add_argument(
+            "-r",
+            "--relationship",
+            action="store_true",
+            help="Propagate counts up all relationships,",
+        )
         # NO --relationships                -> None
         # --relationships part_of regulates -> relationships=['part_of', 'regulates']
         # --relationships=part_of           -> relationships=['part_of']
         # --relationships=part_of,regulates -> relationships=['part_of', 'regulates']
         # --relationships=part_of regulates -> NOT VALID
-        p.add_argument('--relationships', nargs='*',
-                       help=('Propagate counts up user-specified relationships, which include: '
-                             '{RELS}').format(RELS=' '.join(RELATIONSHIP_LIST)))
-        p.add_argument('--method', default="bonferroni,sidak,holm,fdr_bh", type=str,
-                       help=Methods().getmsg_valid_methods())
-        p.add_argument('--pvalcalc', default="fisher_scipy_stats", choices=FisherFactory.options.keys(),
-                       help=str(FisherFactory()))
-        p.add_argument('--min_overlap', default=0.7, type=float,
-                       help="Check that a minimum amount of study genes are in the population")
-        p.add_argument('--goslim', default='goslim_generic.obo', type=str,
-                       help="The GO slim file is used when grouping GO terms.")
-        p.add_argument('--ev_inc', type=str,
-                       help="Include specified evidence codes and groups separated by commas")
-        p.add_argument('--ev_exc', type=str,
-                       help="Exclude specified evidence codes and groups separated by commas")
-        p.add_argument('--ev_help', dest='ev_help', action='store_false',
-                       help="Print all Evidence codes, with descriptions")
-        p.add_argument('--ev_help_short', dest='ev_help_short', action='store_false',
-                       help="Print all Evidence codes")
+        p.add_argument(
+            "--relationships",
+            nargs="*",
+            help=(
+                "Propagate counts up user-specified relationships, which include: "
+                "{RELS}"
+            ).format(RELS=" ".join(RELATIONSHIP_LIST)),
+        )
+        p.add_argument(
+            "--method",
+            default="bonferroni,sidak,holm,fdr_bh",
+            type=str,
+            help=Methods().getmsg_valid_methods(),
+        )
+        p.add_argument(
+            "--obsolete",
+            choices=("keep", "replace", "skip"),
+            default="keep",
+            help="Strategy for handling obsolete GO terms",
+        )
+        p.add_argument(
+            "--pvalcalc",
+            default="fisher_scipy_stats",
+            choices=FisherFactory.options.keys(),
+            help=str(FisherFactory()),
+        )
+        p.add_argument(
+            "--min_overlap",
+            default=0.7,
+            type=float,
+            help="Check that a minimum amount of study genes are in the population",
+        )
+        p.add_argument(
+            "--goslim",
+            default="goslim_generic.obo",
+            type=str,
+            help="The GO slim file is used when grouping GO terms.",
+        )
+        p.add_argument(
+            "--ev_inc",
+            type=str,
+            help="Include specified evidence codes and groups separated by commas",
+        )
+        p.add_argument(
+            "--ev_exc",
+            type=str,
+            help="Exclude specified evidence codes and groups separated by commas",
+        )
+        p.add_argument(
+            "--ev_help",
+            dest="ev_help",
+            action="store_false",
+            help="Print all Evidence codes, with descriptions",
+        )
+        p.add_argument(
+            "--ev_help_short",
+            dest="ev_help_short",
+            action="store_false",
+            help="Print all Evidence codes",
+        )
         # remove_goids: TBD
         #   None (Default) Remove a small number (~14) of broad GO IDs from the association
         #   True           Remove a slightly larger number of broad GO IDs (~100)
@@ -170,17 +293,17 @@ class GoeaCliArgs:
 
     @staticmethod
     def _prt_evidence_codes(args):
-        if not {'--ev_help', '--ev_help_short'}.isdisjoint(args):
-            print('\nEVIDENCE CODE HELP: --ev_exc --ev_inc')
-            print('Use any of these group names, ')
-            print('like Experimental or Similarity or Experimental,Similarity,')
-            print('or evidence codes, like IEA or ISS,ISO,ISA in --ev_exc or --ev_inc:')
+        if not {"--ev_help", "--ev_help_short"}.isdisjoint(args):
+            print("\nEVIDENCE CODE HELP: --ev_exc --ev_inc")
+            print("Use any of these group names, ")
+            print("like Experimental or Similarity or Experimental,Similarity,")
+            print("or evidence codes, like IEA or ISS,ISO,ISA in --ev_exc or --ev_inc:")
             obj = EvidenceCodes()
-            if '--ev_help' in args:
-                print('')
+            if "--ev_help" in args:
+                print("")
                 obj.prt_details()
-            if '--ev_help_short' in args:
-                print('')
+            if "--ev_help_short" in args:
+                print("")
                 obj.prt_summary_code()
             sys.exit(0)
 
@@ -192,7 +315,9 @@ class GoeaCliArgs:
             parser.print_help()
             msg = """
       3 Expected files; Expected content: study population association",
-      {} Actual   files: {}""".format(len(nspc.filenames), ' '.join(nspc.filenames))
+      {} Actual   files: {}""".format(
+                len(nspc.filenames), " ".join(nspc.filenames)
+            )
             raise Exception(msg)
         for fin in nspc.filenames:
             if not os.path.exists(fin):
@@ -210,11 +335,10 @@ class GoeaCliArgs:
         if args.relationship:
             args.relationships = RELATIONSHIP_SET
         if args.relationships is not None:
-            if len(args.relationships) == 1 and ',' in args.relationships[0]:
-                args.relationships = args.relationships[0].split(',')
+            if len(args.relationships) == 1 and "," in args.relationships[0]:
+                args.relationships = args.relationships[0].split(",")
             args.relationships = set(args.relationships)
             chk_relationships(args.relationships)
-
 
 
 class GoeaCliFnc:
@@ -223,7 +347,9 @@ class GoeaCliFnc:
     # pylint: disable=too-many-instance-attributes
     def __init__(self, args):
         self.args = args
-        self.sections = read_sections(self.args.sections) if self.args.sections else None
+        self.sections = (
+            read_sections(self.args.sections) if self.args.sections else None
+        )
         godag_optional_attrs = self._get_optional_attrs()
         self.godag = GODag(obo_file=self.args.obo, optional_attrs=godag_optional_attrs)
         ## print('ARGS GoeaCliFnc ', self.args)
@@ -248,34 +374,37 @@ class GoeaCliFnc:
         anno_type = get_anno_desc(assoc_fn, None)
         # Default annotation file format is id2gos
         if anno_type is None:
-            anno_type = self.args.annofmt if self.args.annofmt else 'id2gos'
+            anno_type = self.args.annofmt if self.args.annofmt else "id2gos"
         # kws: namespaces taxid godag
         kws = self._get_kws_objanno(anno_type)
         return get_objanno(assoc_fn, anno_type, **kws)
 
     def _get_ns(self):
         """Return namespaces."""
-        exp_nss = {'BP', 'MF', 'CC'}
-        act_nss = set(self.args.ns.split(','))
-        assert not act_nss.difference(exp_nss), 'EXPECTED NAMESPACES({E}); GOT({A})'.format(
-            E=','.join(exp_nss), A=','.join(act_nss.difference(exp_nss)))
+        exp_nss = {"BP", "MF", "CC"}
+        act_nss = set(self.args.ns.split(","))
+        assert not act_nss.difference(
+            exp_nss
+        ), "EXPECTED NAMESPACES({E}); GOT({A})".format(
+            E=",".join(exp_nss), A=",".join(act_nss.difference(exp_nss))
+        )
         return None if act_nss == exp_nss else act_nss
 
     def _get_kws_objanno(self, anno_type):
         """Get keyword-args for creating an Annotation object"""
-        kws = {'namespaces': self._get_ns(), 'godag': self.godag}
-        if anno_type == 'gene2go':
-            kws['taxid'] = self.args.taxid
+        kws = {"namespaces": self._get_ns(), "godag": self.godag}
+        if anno_type == "gene2go":
+            kws["taxid"] = self.args.taxid
         return kws
 
     def _init_itemid2name(self):
         """Print gene symbols instead of gene IDs, if provided."""
-        if not hasattr(self.args, 'id2sym'):
+        if not hasattr(self.args, "id2sym"):
             return None
         fin_id2sym = self.args.id2sym
         if fin_id2sym is not None and os.path.exists(fin_id2sym):
             id2sym = {}
-            cmpl = re.compile(r'^\s*(\S+)[\s,;]+(\S+)')
+            cmpl = re.compile(r"^\s*(\S+)[\s,;]+(\S+)")
             with open(fin_id2sym) as ifstrm:
                 for line in ifstrm:
                     mtch = cmpl.search(line)
@@ -300,11 +429,11 @@ class GoeaCliFnc:
 
     def prt_outfiles_flat(self, goea_results, outfiles):
         """Write to outfiles."""
-        kws = {'indent':self.args.indent, 'itemid2name':self.itemid2name}
+        kws = {"indent": self.args.indent, "itemid2name": self.itemid2name}
         for outfile in outfiles:
             if outfile.endswith(".xlsx"):
                 self.objgoeans.wr_xlsx(outfile, goea_results, **kws)
-            #elif outfile.endswith(".txt"):  # TBD
+            # elif outfile.endswith(".txt"):  # TBD
             #    pass
             else:
                 self.objgoeans.wr_tsv(outfile, goea_results, **kws)
@@ -325,7 +454,9 @@ class GoeaCliFnc:
 
     def get_results(self):
         """Return the significant GOEA results (< pval), unless user wants all."""
-        results = self.get_results_sig() if 0 <= self.args.pval < 1.0 else self.results_all
+        results = (
+            self.get_results_sig() if 0 <= self.args.pval < 1.0 else self.results_all
+        )
         if self.args.prt_study_gos_only:
             results = [r for r in results if r.study_count != 0]
         return results
@@ -335,55 +466,73 @@ class GoeaCliFnc:
         ns2assoc = self.objanno.get_ns2assc(**self._get_anno_kws())
         ## BROAD rm_goids = self._get_remove_goids()
         rm_goids = False  # BROAD
-        return GOEnrichmentStudyNS(pop, ns2assoc, self.godag,
-                                   propagate_counts=not self.args.no_propagate_counts,
-                                   relationships=self.args.relationships,
-                                   alpha=self.args.alpha,
-                                   pvalcalc=self.args.pvalcalc,
-                                   methods=self.methods,
-                                   remove_goids=rm_goids)
+        return GOEnrichmentStudyNS(
+            pop,
+            ns2assoc,
+            self.godag,
+            propagate_counts=not self.args.no_propagate_counts,
+            relationships=self.args.relationships,
+            alpha=self.args.alpha,
+            pvalcalc=self.args.pvalcalc,
+            methods=self.methods,
+            remove_goids=rm_goids,
+        )
+
     def _get_anno_kws(self):
         """Return keyword options to obtain id2gos"""
         kws = {}
         if self.args.ev_inc is not None:
-            kws['ev_include'] = set(self.args.ev_inc.split(','))
+            kws["ev_include"] = set(self.args.ev_inc.split(","))
         if self.args.ev_exc is not None:
-            kws['ev_exclude'] = set(self.args.ev_exc.split(','))
+            kws["ev_exclude"] = set(self.args.ev_exc.split(","))
         return kws
 
     def chk_genes(self, study, pop, ntsassoc=None):
         """Compare population and study gene product sets"""
         if len(pop) < len(study):
-            exit("\nERROR: The study file contains more elements than the population file. "
-                 "Please check that the study file is a subset of the population file.\n")
+            exit(
+                "\nERROR: The study file contains more elements than the population file. "
+                "Please check that the study file is a subset of the population file.\n"
+            )
         # check the fraction of genomic ids that overlap between study and population
         overlap = self.get_overlap(study, pop)
         if overlap < 0.95:
-            sys.stderr.write("\nWARNING: only {} fraction of genes/proteins in study are found in "
-                             "the population background.\n\n".format(overlap))
+            sys.stderr.write(
+                "\nWARNING: only {} fraction of genes/proteins in study are found in "
+                "the population background.\n\n".format(overlap)
+            )
         if overlap <= self.args.min_overlap:
-            exit("\nERROR: only {} of genes/proteins in the study are found in the "
-                 "background population. Please check.\n".format(overlap))
+            exit(
+                "\nERROR: only {} of genes/proteins in the study are found in the "
+                "background population. Please check.\n".format(overlap)
+            )
         # Population and associations
         if ntsassoc is not None:
             assc_ids = set(nt.DB_ID for nt in ntsassoc)
             if pop.isdisjoint(assc_ids):
-                if self.objanno.name == 'gene2go':
-                    err = ('**FATAL: NO POPULATION ITEMS SEEN IN THE NCBI gene2go ANNOTATIONS '
-                           'FOR taxid({T}). TRY: --taxid=<taxid number>')
+                if self.objanno.name == "gene2go":
+                    err = (
+                        "**FATAL: NO POPULATION ITEMS SEEN IN THE NCBI gene2go ANNOTATIONS "
+                        "FOR taxid({T}). TRY: --taxid=<taxid number>"
+                    )
                     exit(err.format(T=next(iter(self.objanno.taxid2asscs.keys()))))
                 else:
-                    exit('**FATAL: NO POPULATION ITEMS SEEN IN THE ANNOTATIONS')
+                    exit("**FATAL: NO POPULATION ITEMS SEEN IN THE ANNOTATIONS")
 
     def get_results_sig(self):
         """Get significant results."""
         # Only print results when uncorrected p-value < this value.
-        print("{N:7,} of {M:,} results have uncorrected P-values <= {PVAL}=pval\n".format(
-            N=sum(1 for r in self.results_all if r.p_uncorrected < self.args.pval),
-            M=len(self.results_all),
-            PVAL=self.args.pval))
+        print(
+            "{N:7,} of {M:,} results have uncorrected P-values <= {PVAL}=pval\n".format(
+                N=sum(1 for r in self.results_all if r.p_uncorrected < self.args.pval),
+                M=len(self.results_all),
+                PVAL=self.args.pval,
+            )
+        )
         pval_fld = self.get_pval_field()
-        results = [r for r in self.results_all if getattr(r, pval_fld) <= self.args.pval]
+        results = [
+            r for r in self.results_all if getattr(r, pval_fld) <= self.args.pval
+        ]
         return results
 
     @staticmethod
@@ -396,19 +545,23 @@ class GoeaCliFnc:
         pval_fld = self.args.pval_field
         # If --pval_field [VAL] was specified
         if pval_fld is not None:
-            if pval_fld[:2] != 'p_':
-                pval_fld = 'p_' + pval_fld
+            if pval_fld[:2] != "p_":
+                pval_fld = "p_" + pval_fld
         # If only one method was used, use that instead of the uncorrected pvalue
         elif len(self.methods) == 1:
-            pval_fld = 'p_' + self.methods[0]
+            pval_fld = "p_" + self.methods[0]
         # Use 'uncorrected pvalue' if there are many methods & none chosen using --pval_field
         else:
-            pval_fld = 'p_uncorrected'
+            pval_fld = "p_uncorrected"
         if self.results_all:
-            assert hasattr(next(iter(self.results_all)), pval_fld), \
-                'NO PVAL({P}). EXPECTED ONE OF: {E}'.format(
-                    P=self.args.pval_field,
-                    E=" ".join([k for k in dir(next(iter(self.results_all))) if k[:2] == 'p_']))
+            assert hasattr(
+                next(iter(self.results_all)), pval_fld
+            ), "NO PVAL({P}). EXPECTED ONE OF: {E}".format(
+                P=self.args.pval_field,
+                E=" ".join(
+                    [k for k in dir(next(iter(self.results_all))) if k[:2] == "p_"]
+                ),
+            )
         return pval_fld
 
     def rd_files(self, study_fn, pop_fn):
@@ -434,18 +587,23 @@ class GoeaCliFnc:
             pop -= common
             study -= common
             sys.stderr.write("removed %d overlapping items\n" % (len(common)))
-            sys.stderr.write("Set 1: {0}, Set 2: {1}\n".format(
-                len(study), len(pop)))
+            sys.stderr.write("Set 1: {0}, Set 2: {1}\n".format(len(study), len(pop)))
         return study, pop
 
     def _get_optional_attrs(self):
         """Given keyword args, return optional_attributes to be loaded into the GODag."""
         if self.args.relationship:
-            return {'relationship',}
+            return {
+                "relationship",
+            }
         if self.args.relationships is not None:
-            return {'relationship',}
+            return {
+                "relationship",
+            }
         if self.sections:
-            return {'relationship',}
+            return {
+                "relationship",
+            }
         return None
 
     def _get_remove_goids(self):
@@ -454,16 +612,17 @@ class GoeaCliFnc:
         if self.args.remove_goids is None:
             return self.args.remove_goids
         # True: Remove a slightly larger number of broad GO IDs (~100)
-        if self.args.remove_goids.lower() == 'true':
+        if self.args.remove_goids.lower() == "true":
             return True
         # False: Do not remove any broad GO IDs
-        if self.args.remove_goids.lower() == 'false':
+        if self.args.remove_goids.lower() == "false":
             return False
         if os.path.exists(self.args.remove_goids):
             GetGOs.rdtxt_gos(self.args.remove_goids, sys.stdout)
-        if isinstance(self.args.remove_goids, str) and 'GO' in self.args.remove_goids:
-            return self.args.remove_goids.split(',')
+        if isinstance(self.args.remove_goids, str) and "GO" in self.args.remove_goids:
+            return self.args.remove_goids.split(",")
         return None
+
 
 class GroupItems:
     """Prepare for grouping, if specified by the user."""
@@ -473,13 +632,19 @@ class GroupItems:
         _goids = set(r.GO for r in objcli.results_all)
         _tobj = TermCounts(objcli.godag, objcli.objgoeans.get_assoc())
         # pylint: disable=line-too-long
-        self.gosubdag = GoSubDag(_goids, objcli.godag, relationships=True, tcntobj=_tobj, prt=sys.stdout)
+        self.gosubdag = GoSubDag(
+            _goids, objcli.godag, relationships=True, tcntobj=_tobj, prt=sys.stdout
+        )
         self.grprdflt = GrouperDflts(self.gosubdag, objcli.args.goslim)
-        self.hdrobj = HdrgosSections(self.grprdflt.gosubdag, self.grprdflt.hdrgos_dflt, objcli.sections)
+        self.hdrobj = HdrgosSections(
+            self.grprdflt.gosubdag, self.grprdflt.hdrgos_dflt, objcli.sections
+        )
         self.pval_fld = objcli.get_pval_field()  # primary pvalue of interest
-        self.ver_list = [godag_version,
-                         self.grprdflt.ver_goslims,
-                         "Sections: {S}".format(S=objcli.args.sections)]
+        self.ver_list = [
+            godag_version,
+            self.grprdflt.ver_goslims,
+            "Sections: {S}".format(S=objcli.args.sections),
+        ]
         # self.objaartall = self._init_objaartall()
 
     def get_objgrpwr(self, goea_results):
@@ -491,8 +656,10 @@ class GroupItems:
         """Return a Grouper object, given a list of GOEnrichmentRecord."""
         nts_goea = MgrNtGOEAs(goea_results).get_goea_nts_prt(**kws)
         goids = set(nt.GO for nt in nts_goea)
-        go2nt = {nt.GO:nt for nt in nts_goea}
-        grprobj = Grouper("GOEA", goids, self.hdrobj, self.grprdflt.gosubdag, go2nt=go2nt)
+        go2nt = {nt.GO: nt for nt in nts_goea}
+        grprobj = Grouper(
+            "GOEA", goids, self.hdrobj, self.grprdflt.gosubdag, go2nt=go2nt
+        )
         grprobj.prt_summary(sys.stdout)
         # hdrgo_prt", "section_prt", "top_n", "use_sections"
         sortobj = Sorter(grprobj, section_sortby=lambda nt: getattr(nt, self.pval_fld))
@@ -507,19 +674,24 @@ class GroupItems:
     def _init_objaartall(self):
         """Get background database info for making ASCII art."""
         kws = {
-            'sortgo':lambda nt: [nt.NS, nt.dcnt],
+            "sortgo": lambda nt: [nt.NS, nt.dcnt],
             # fmtgo=('{p_fdr_bh:8.2e} {GO} '
             # Formatting for GO terms in grouped GO list
-            'fmtgo':('{hdr1usr01:2} {NS} {GO} {s_fdr_bh:8} '
-                     '{dcnt:5} {childcnt:3} R{reldepth:02} '
-                     '{D1:5} {GO_name} ({study_count} study genes)\n'),
+            "fmtgo": (
+                "{hdr1usr01:2} {NS} {GO} {s_fdr_bh:8} "
+                "{dcnt:5} {childcnt:3} R{reldepth:02} "
+                "{D1:5} {GO_name} ({study_count} study genes)\n"
+            ),
             # Formatting for GO terms listed under each gene
-            'fmtgo2':('{hdr1usr01:2} {NS} {GO} {s_fdr_bh:8} '
-                      '{dcnt:5} R{reldepth:02} '
-                      '{GO_name} ({study_count} study genes)\n'),
+            "fmtgo2": (
+                "{hdr1usr01:2} {NS} {GO} {s_fdr_bh:8} "
+                "{dcnt:5} R{reldepth:02} "
+                "{GO_name} ({study_count} study genes)\n"
+            ),
             # itemid2name=ensmusg2symbol}
-            }
+        }
         return AArtGeneProductSetsAll(self.grprdflt, self.hdrobj, **kws)
+
 
 class GrpWr:
     """Write GO term GOEA information, grouped."""
@@ -554,26 +726,28 @@ class GrpWr:
         #     'ratio_in_study': {'align':'right'},
         #     'ratio_in_pop':{'align':'right'}}
         kws_xlsx = {
-            'title': self.ver_list,
-            'fld2fmt': {f:'{:8.2e}' for f in self.flds_cur if f[:2] == 'p_'},
+            "title": self.ver_list,
+            "fld2fmt": {f: "{:8.2e}" for f in self.flds_cur if f[:2] == "p_"},
             #'ntfld_wbfmt': ntfld_wbfmt,
             #### 'ntval2wbfmtdict': ntval2wbfmtdict,
             #'hdrs': [],
-            'prt_flds': self.flds_cur}
+            "prt_flds": self.flds_cur,
+        }
         objwr.wr_xlsx_nts(fout_xlsx, self.desc2nts, **kws_xlsx)
 
     def wr_tsv(self, fout_tsv):
         """Print grouped GOEA results into a tab-separated file."""
-        with open(fout_tsv, 'w') as prt:
+        with open(fout_tsv, "w") as prt:
             kws_tsv = {
-                'fld2fmt': {f:'{:8.2e}' for f in self.flds_cur if f[:2] == 'p_'},
-                'prt_flds':self.flds_cur}
-            prt_tsv_sections(prt, self.desc2nts['sections'], **kws_tsv)
+                "fld2fmt": {f: "{:8.2e}" for f in self.flds_cur if f[:2] == "p_"},
+                "prt_flds": self.flds_cur,
+            }
+            prt_tsv_sections(prt, self.desc2nts["sections"], **kws_tsv)
             print("  WROTE: {TSV}".format(TSV=fout_tsv))
 
     def wr_txt(self, fout_txt):
         """Write to a file GOEA results in an ASCII text format."""
-        with open(fout_txt, 'w') as prt:
+        with open(fout_txt, "w") as prt:
             for line in self.ver_list:
                 prt.write("{LINE}\n".format(LINE=line))
             self.prt_txt(prt)
@@ -583,13 +757,13 @@ class GrpWr:
         """Print an ASCII text format."""
         prtfmt = self.objprtfmt.get_prtfmt_str(self.flds_cur)
         prt.write("{FLDS}\n".format(FLDS=" ".join(self.flds_cur)))
-        WrSectionsTxt.prt_sections(prt, self.desc2nts['sections'], prtfmt, secspc=True)
+        WrSectionsTxt.prt_sections(prt, self.desc2nts["sections"], prtfmt, secspc=True)
 
     def prt_txt(self, prt=sys.stdout):
         """Print an ASCII text format."""
         prtfmt = self.objprtfmt.get_prtfmt_str(self.flds_cur)
         prt.write("{FLDS}\n".format(FLDS=" ".join(self.flds_cur)))
-        WrSectionsTxt.prt_sections(prt, self.desc2nts['sections'], prtfmt, secspc=True)
+        WrSectionsTxt.prt_sections(prt, self.desc2nts["sections"], prtfmt, secspc=True)
 
     def _init_flds_cur(self):
         """Choose fields to print from a multitude of available fields."""
@@ -603,14 +777,24 @@ class GrpWr:
         # 'is_hdrgo', 'is_usrgo', 'num_usrgos', 'hdr1usr01', 'alt', 'GO_name',
         # 'dcnt', 'D1', 'tcnt', 'tfreq', 'tinfo', 'childcnt', 'REL',
         # 'REL_short', 'rel', 'id')
-        flds0 = ['GO', 'NS', 'enrichment', self.pval_fld, 'dcnt', 'tinfo', 'depth',
-                 'ratio_in_study', 'ratio_in_pop', 'name']
-        flds_p = [f for f in self.flds_all if f[:2] == 'p_' and f != self.pval_fld]
+        flds0 = [
+            "GO",
+            "NS",
+            "enrichment",
+            self.pval_fld,
+            "dcnt",
+            "tinfo",
+            "depth",
+            "ratio_in_study",
+            "ratio_in_pop",
+            "name",
+        ]
+        flds_p = [f for f in self.flds_all if f[:2] == "p_" and f != self.pval_fld]
         flds.extend(flds0)
         if flds_p:
             flds.extend(flds_p)
-        flds.append('study_count')
-        flds.append('study_items')
+        flds.append("study_count")
+        flds.append("study_items")
         return flds
 
 

--- a/goatools/cli/find_enrichment.py
+++ b/goatools/cli/find_enrichment.py
@@ -354,7 +354,7 @@ class GoeaCliFnc:
         self.godag = GODag(
             obo_file=self.args.obo,
             optional_attrs=godag_optional_attrs,
-            load_obsolete=self.args.obsolete in ("keep", "replace"),
+            load_obsolete=True,
         )
         # GET: Gene2GoReader, GafReader, GpadReader, or IdToGosReader
         self.objanno = self._get_objanno(self.args.filenames[2])

--- a/goatools/cli/find_enrichment.py
+++ b/goatools/cli/find_enrichment.py
@@ -586,8 +586,8 @@ class GoeaCliFnc:
             pop |= study
             pop -= common
             study -= common
-            sys.stderr.write("removed %d overlapping items\n" % (len(common)))
-            sys.stderr.write("Set 1: {0}, Set 2: {1}\n".format(len(study), len(pop)))
+            sys.stderr.write(f"removed {len(common)} overlapping items\n")
+            sys.stderr.write(f"Set 1: {len(study)}, Set 2: {len(pop)}\n")
         return study, pop
 
     def _get_optional_attrs(self):

--- a/goatools/cli/find_enrichment.py
+++ b/goatools/cli/find_enrichment.py
@@ -233,7 +233,7 @@ class GoeaCliArgs:
         p.add_argument(
             "--obsolete",
             choices=("keep", "replace", "skip"),
-            default="keep",
+            default="skip",
             help="Strategy for handling obsolete GO terms",
         )
         p.add_argument(

--- a/goatools/obo_parser.py
+++ b/goatools/obo_parser.py
@@ -45,7 +45,7 @@ class OBOReader(object):
         self.data_version = (
             None  # e.g., "releases/2016-07-07" from "data-version:" line
         )
-        self.default_namespace = 'default'
+        self.default_namespace = "default"
         self.typedefs = {}
 
         # True if obo file exists or if a link to an obo file exists.
@@ -109,7 +109,7 @@ class OBOReader(object):
         if line[0:12] == "data-version":
             self.data_version = line[14:-1]
             return True
-        if line[:17] == 'default-namespace':
+        if line[:17] == "default-namespace":
             self.default_namespace = line[18:].strip()
             return True
         if line[0:6].lower() == "[term]":
@@ -160,7 +160,7 @@ class GOTerm(object):
     GO term, actually contain a lot more properties than interfaced here
     """
 
-    def __init__(self, default_namespace='default'):
+    def __init__(self, default_namespace="default"):
         self.id = ""  # GO:NNNNNNN  **DEPRECATED** RESERVED NAME IN PYTHON
         self.item_id = ""  # GO:NNNNNNN (will replace deprecated "id")
         self.name = ""  # description
@@ -197,7 +197,7 @@ class GOTerm(object):
                         for elem in val:
                             ret.append("  {ELEM}".format(ELEM=elem))
                     else:
-                        for (typedef, terms) in val.items():
+                        for typedef, terms in val.items():
                             ret.append(
                                 "  {TYPEDEF}: {NTERMS} items".format(
                                     TYPEDEF=typedef, NTERMS=len(terms)
@@ -314,7 +314,7 @@ class GODag(dict):
         self,
         obo_file="go-basic.obo",
         optional_attrs=None,
-        load_obsolete=False,
+        load_obsolete: str = False,
         prt=stdout,
     ):
         super(GODag, self).__init__()
@@ -427,7 +427,6 @@ class GODag(dict):
         ####     return rec.reldepth
 
         for rec in self.values():
-
             #### MOVED TO goatools/godag/reldepth.py:
             #### # Add invert relationships
             #### if has_relationship:

--- a/goatools/obo_parser.py
+++ b/goatools/obo_parser.py
@@ -53,11 +53,11 @@ class OBOReader(object):
             self.obo_file = obo_file
             # GOTerm attributes that are necessary for any operations:
         else:
-            raise Exception(
-                "COULD NOT READ({OBO})\n"
+            raise ValueError(
+                f"COULD NOT READ({obo_file})\n"
                 "download obo file first\n "
                 "[http://geneontology.org/ontology/"
-                "go-basic.obo]".format(OBO=obo_file)
+                "go-basic.obo]"
             )
 
     def __iter__(self):
@@ -186,27 +186,23 @@ class GOTerm(object):
 
     def __repr__(self):
         """Print GO ID and all attributes in GOTerm class."""
-        ret = ["GOTerm('{ID}'):".format(ID=self.item_id)]
+        ret = [f"GOTerm('{self.item_id}'):"]
         for key, val in self.__dict__.items():
             if isinstance(val, (int, str)):
-                ret.append("{K}:{V}".format(K=key, V=val))
+                ret.append(f"{key}:{val}")
             elif val is not None:
-                ret.append("{K}: {V} items".format(K=key, V=len(val)))
+                ret.append(f"{key}: {len(val)} items")
                 if len(val) < 10:
                     if not isinstance(val, dict):
                         for elem in val:
-                            ret.append("  {ELEM}".format(ELEM=elem))
+                            ret.append(f"  {elem}")
                     else:
                         for typedef, terms in val.items():
-                            ret.append(
-                                "  {TYPEDEF}: {NTERMS} items".format(
-                                    TYPEDEF=typedef, NTERMS=len(terms)
-                                )
-                            )
+                            ret.append(f"  {typedef}: {len(terms)} items")
                             for term in terms:
-                                ret.append("    {TERM}".format(TERM=term))
+                                ret.append(f"    {term}")
             else:
-                ret.append("{K}: None".format(K=key))
+                ret.append(f"{key}: None")
         return "\n  ".join(ret)
 
     def has_parent(self, term):

--- a/goatools/obo_parser.py
+++ b/goatools/obo_parser.py
@@ -6,11 +6,11 @@
 
 """Read and store Gene Ontology's obo file."""
 # -*- coding: UTF-8 -*-
-from __future__ import print_function
-
-from sys import stdout
-from sys import stderr
 import os
+
+from sys import stderr, stdout
+from typing import Optional
+
 from goatools.godag.obo_optional_attributes import OboOptionalAttrs
 from goatools.godag.typedef import TypeDef
 from goatools.godag.typedef import add_to_typedef
@@ -312,9 +312,9 @@ class GODag(dict):
     # pylint: disable=line-too-long
     def __init__(
         self,
-        obo_file="go-basic.obo",
-        optional_attrs=None,
-        load_obsolete: str = False,
+        obo_file: str = "go-basic.obo",
+        optional_attrs: Optional[set] = None,
+        load_obsolete: bool = False,
         prt=stdout,
     ):
         super(GODag, self).__init__()
@@ -416,39 +416,9 @@ class GODag(dict):
                     rec.depth = 0
             return rec.depth
 
-        #### MOVED TO goatools/godag/reldepth.py:
-        #### def _init_reldepth(rec):
-        ####     if not hasattr(rec, 'reldepth'):
-        ####         up_terms = rec.get_goterms_upper()
-        ####         if up_terms:
-        ####             rec.reldepth = max(_init_reldepth(rec) for rec in up_terms) + 1
-        ####         else:
-        ####             rec.reldepth = 0
-        ####     return rec.reldepth
-
         for rec in self.values():
-            #### MOVED TO goatools/godag/reldepth.py:
-            #### # Add invert relationships
-            #### if has_relationship:
-            ####     if rec.depth is None:
-            ####         _init_reldepth(rec)
-
-            ####     # print("BBBBBBBBBBB1", rec.item_id, rec.relationship)
-            ####     #for (typedef, terms) in rec.relationship.items():
-            ####     #    invert_typedef = self.typedefs[typedef].inverse_of
-            ####     #    # print("BBBBBBBBBBB2 {} ({}) ({}) ({})".format(
-            ####     #    #    rec.item_id, rec.relationship, typedef, invert_typedef))
-            ####     #    if invert_typedef:
-            ####     #        # Add inverted relationship
-            ####     #        for term in terms:
-            ####     #            if not hasattr(term, 'relationship'):
-            ####     #                term.relationship = defaultdict(set)
-            ####     #            term.relationship[invert_typedef].add(rec)
-            ####     # print("BBBBBBBBBBB3", rec.item_id, rec.relationship)
-
             if rec.level is None:
                 _init_level(rec)
-
             if rec.depth is None:
                 _init_depth(rec)
 

--- a/goatools/obo_parser.py
+++ b/goatools/obo_parser.py
@@ -415,6 +415,7 @@ class GODag(dict):
         for rec in self.values():
             if rec.level is None:
                 _init_level(rec)
+
             if rec.depth is None:
                 _init_depth(rec)
 


### PR DESCRIPTION
This PR adds option `--obsolete` to `find_enrichment.py`.

```console
  --obsolete {keep,replace,skip}
                        Strategy for handling obsolete GO terms (default: skip)
```

The `replace` strategy updates the obsolete GO term with terms suggested in `replaced_by` and `consider`.