### PR TITLE
Fix #339: honor log=None in GOEnrichmentStudy; speed up per-file pytest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          uv run pytest
+          make test_ci_subset

--- a/goatools/anno/update_association.py
+++ b/goatools/anno/update_association.py
@@ -23,7 +23,7 @@ def update_association(assc_gene2gos, go2obj, relationships=None, prt=sys.stdout
     # Get all assc GO IDs that are current
     assc_goid_sets = assc_gene2gos.values()
     goids_assoc_all = set.union(*assc_goid_sets)
-    _chk_goids_notfound(goids_assoc_all, goids_avail)
+    _chk_goids_notfound(goids_assoc_all, goids_avail, prt)
     # Get the subset of GO objects in the association
     _goids_assoc_cur = goids_assoc_all.intersection(goids_avail)
     _go2obj_assc = {go:go2obj[go] for go in _goids_assoc_cur}
@@ -36,11 +36,11 @@ def update_association(assc_gene2gos, go2obj, relationships=None, prt=sys.stdout
                 parents.update(go2ancestors[goid])
         assc_goids_cur.update(parents)
 
-def _chk_goids_notfound(goids_assoc_all, goids_avail):
+def _chk_goids_notfound(goids_assoc_all, goids_avail, prt=sys.stderr):
     """Report the number of GO IDs in the association, but not in the GODAG"""
     goids_bad = goids_assoc_all.difference(goids_avail)
-    if goids_bad:
-        sys.stderr.write("{N} GO IDs NOT FOUND IN ASSOCIATION: {GOs}\n".format(
+    if goids_bad and prt:
+        prt.write("{N} GO IDs NOT FOUND IN ASSOCIATION: {GOs}\n".format(
             N=len(goids_bad), GOs=" ".join(goids_bad)))
 
 def remove_assc_goids(assoc, broad_goids):

--- a/goatools/go_enrichment.py
+++ b/goatools/go_enrichment.py
@@ -325,7 +325,9 @@ class GOEnrichmentStudy(object):
         self.pval_obj = FisherFactory(**kws).pval_obj
 
         if propagate_counts:
-            update_association(assoc, obo_dag, kws.get("relationships", None))
+            update_association(
+                assoc, obo_dag, kws.get("relationships"), prt=self.log
+            )
         # BROAD broad_goids = get_goids_to_remove(kws.get('remove_goids'))
         # BROAD if broad_goids:
         # BROAD     assoc = self._remove_assc_goids(assoc, broad_goids)

--- a/makefile
+++ b/makefile
@@ -366,7 +366,56 @@ chk_parsers:
 
 # This representative test subset is automatically run for all push requests in GitHub Actions.
 # Running a subset of tests prevents CI from timing out.
+CI_TESTS = \
+    tests/test_altid_godag.py \
+    tests/test_altid_gosubdag.py \
+    tests/test_annotations_gaf.py::test_gaf_read_fb \
+    tests/test_cli_write_hierarchy.py \
+    tests/test_combine_nt_lists.py \
+    tests/test_compare_gos.py \
+    tests/test_david_nts.py \
+    tests/test_dcnt_r01.py \
+    tests/test_genes_cell_cycle.py \
+    tests/test_get_children.py \
+    tests/test_get_godag.py \
+    tests/test_get_parents.py \
+    tests/test_get_paths.py \
+    tests/test_get_unique_fields.py \
+    tests/test_go_depth1.py \
+    tests/test_go_draw.py \
+    tests/test_go_name_shorten.py \
+    tests/test_goea_errors.py \
+    tests/test_fold_enrichment.py \
+    tests/test_goea_local.py::test_unknown_gos \
+    tests/test_goea_rpt_bonferroni.py \
+    tests/test_goea_statsmodels.py \
+    tests/test_gosearch_emptydict.py \
+    tests/test_gosearch_fields.py \
+    tests/test_gosubdag_relationships.py \
+    tests/test_grpr_get_sections_2d.py \
+    tests/test_grprobj.py \
+    tests/test_i92_relationship_parentchild.py \
+    tests/test_i96_goea_ncbi.py \
+    tests/test_i339_silent_init.py \
+    tests/test_mapslim.py \
+    tests/test_multiple_testing.py \
+    tests/test_ncbi_entrez_annotations.py \
+    tests/test_optional_attributes.py \
+    tests/test_parents_ancestors.py \
+    tests/test_pvalcalc.py \
+    tests/test_rpt_gene2go_evidencecodes.py \
+    tests/test_semantic.py \
+    tests/test_sorter_desc2nts.py \
+    tests/test_sorter_sections.py \
+    tests/test_sorter.py \
+    tests/test_study_zero.py \
+    tests/test_wr_py_goea_results.py \
+    tests/test_wr_sections_txt.py \
+    tests/test_wr_tbl_subset.py \
+    tests/test_write_hier.py \
+    tests/test_write_summary_cnts.py
+
 test_ci_subset:
-	uv run pytest
+	uv run pytest --cov=goatools $(CI_TESTS)
 
 # Ctest_wr_hier_CC.txtopyright (C) 2010-2019. Haibao Tang et al. All rights reserved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,52 +19,7 @@ git_describe_command = "git describe --dirty --tags --long --match v* --first-pa
 version_scheme = "no-guess-dev"
 
 [tool.pytest.ini_options]
-addopts = """
--v --cov=goatools
-tests/test_altid_godag.py
-tests/test_altid_gosubdag.py
-tests/test_annotations_gaf.py::test_gaf_read_fb
-tests/test_cli_write_hierarchy.py
-tests/test_combine_nt_lists.py
-tests/test_compare_gos.py
-tests/test_david_nts.py
-tests/test_dcnt_r01.py
-tests/test_genes_cell_cycle.py
-tests/test_get_children.py
-tests/test_get_godag.py
-tests/test_get_parents.py
-tests/test_get_paths.py
-tests/test_get_unique_fields.py
-tests/test_go_depth1.py
-tests/test_go_draw.py
-tests/test_go_name_shorten.py
-tests/test_goea_errors.py
-tests/test_fold_enrichment.py
-tests/test_goea_local.py::test_unknown_gos
-tests/test_goea_rpt_bonferroni.py
-tests/test_goea_statsmodels.py
-tests/test_gosearch_emptydict.py
-tests/test_gosearch_fields.py
-tests/test_gosubdag_relationships.py
-tests/test_grpr_get_sections_2d.py
-tests/test_grprobj.py
-tests/test_i92_relationship_parentchild.py
-tests/test_i96_goea_ncbi.py
-tests/test_mapslim.py
-tests/test_multiple_testing.py
-tests/test_ncbi_entrez_annotations.py
-tests/test_optional_attributes.py
-tests/test_parents_ancestors.py
-tests/test_pvalcalc.py
-tests/test_rpt_gene2go_evidencecodes.py
-tests/test_semantic.py
-tests/test_sorter_desc2nts.py
-tests/test_sorter_sections.py
-tests/test_sorter.py
-tests/test_study_zero.py
-tests/test_wr_py_goea_results.py
-tests/test_wr_sections_txt.py
-tests/test_wr_tbl_subset.py
-tests/test_write_hier.py
-tests/test_write_summary_cnts.py
-"""
+# Keep addopts minimal so per-file invocations (`pytest tests/test_foo.py`)
+# are fast and predictable. The curated CI subset and `--cov` live in the
+# makefile target `test_ci_subset`.
+addopts = "-v"

--- a/tests/test_i339_silent_init.py
+++ b/tests/test_i339_silent_init.py
@@ -1,0 +1,42 @@
+"""Test issue #339: _chk_goids_notfound should honor prt=None.
+
+https://github.com/tanghaibao/goatools/issues/339
+
+Previously _chk_goids_notfound wrote to sys.stderr unconditionally, so
+GOEnrichmentStudy(..., log=None) would still emit the "GO IDs NOT FOUND IN
+ASSOCIATION" message. The fix routes the message through the prt argument.
+"""
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+from goatools.anno.update_association import _chk_goids_notfound
+
+
+def test_i339_chk_goids_notfound_silent_when_prt_none():
+    """_chk_goids_notfound(prt=None) must not write to stdout or stderr."""
+    goids_assoc = {"GO:0000001", "GO:9999999"}  # one missing
+    goids_avail = {"GO:0000001"}
+
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        _chk_goids_notfound(goids_assoc, goids_avail, prt=None)
+
+    assert out.getvalue() == "", f"unexpected stdout: {out.getvalue()!r}"
+    assert err.getvalue() == "", f"unexpected stderr: {err.getvalue()!r}"
+
+
+def test_i339_chk_goids_notfound_writes_to_prt():
+    """When a prt stream is supplied, the missing-GO message is written there."""
+    goids_assoc = {"GO:0000001", "GO:9999999"}
+    goids_avail = {"GO:0000001"}
+
+    prt = io.StringIO()
+    _chk_goids_notfound(goids_assoc, goids_avail, prt=prt)
+
+    assert "GO:9999999" in prt.getvalue()
+
+
+if __name__ == "__main__":
+    test_i339_chk_goids_notfound_silent_when_prt_none()
+    test_i339_chk_goids_notfound_writes_to_prt()


### PR DESCRIPTION
## Summary
- Fix [#339](https://github.com/tanghaibao/goatools/issues/339): `GOEnrichmentStudy(..., log=None)` no longer prints the `Propagating term counts` or `GO IDs NOT FOUND IN ASSOCIATION` messages. `self.log` is now passed through to `update_association`, and `_chk_goids_notfound` writes through `prt` instead of unconditionally to `sys.stderr`.
- Add `tests/test_i339_silent_init.py` covering the silent-init path (runs in ~0.03 s).
- Move the curated CI test list out of `pyproject.toml` `addopts` and into a `CI_TESTS` variable in `makefile`. `pyproject.toml` `addopts` is now just `-v`, so `pytest tests/test_foo.py` actually narrows the run (was silently re-running the full curated suite under `--cov` for ~4 min). CI now calls `make test_ci_subset`.

## Test plan
- [x] `pytest tests/test_i339_silent_init.py` passes in <1s
- [x] `make test_ci_subset` runs the same curated subset CI used to run, including the new test
- [x] Manual repro from #339 with `log=None` produces no stdout/stderr output